### PR TITLE
Fix uglify

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ module.exports = {
     }
 
     if (typeof input !== 'string') {
-      let msg = 'eth-sig-util.normalize() requires hex string or integer input.'
-      msg += ` received ${typeof input}: ${input}`
+      var msg = 'eth-sig-util.normalize() requires hex string or integer input.'
+      msg += ' received ' + (typeof input) + ': ' + input
       throw new Error(msg)
     }
 
@@ -82,7 +82,7 @@ function typedSignatureHash(typedData) {
   const types = typedData.map(function (e) { return e.type })
   const schema = typedData.map(function (e) {
     if (!e.name) throw error
-    return `${e.type} ${e.name}`
+    return e.type + ' ' + e.name
   })
 
   return ethAbi.soliditySHA3(


### PR DESCRIPTION
As mentioned in #9 ,  all the apps created with create-react-app are failing on the uglify step because of the lack of ES5 compatibility.

Getting rid of this minor ES6 features fixes the issue.

Before:

![screen shot 2017-12-19 at 22 21 14](https://user-images.githubusercontent.com/1247834/34189743-08b46e78-e50b-11e7-882c-dca72ed2b9e4.png)

After:

![screen shot 2017-12-19 at 22 21 36](https://user-images.githubusercontent.com/1247834/34189750-0e6669ca-e50b-11e7-82a4-a0084385e770.png)
