### PR TITLE
EIP-712: Array support

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,6 +141,9 @@ const TypedDataUtils = {
     for (const key in TYPED_MESSAGE_SCHEMA.properties) {
       data[key] && (sanitizedData[key] = data[key])
     }
+    if (sanitizedData.types) {
+      sanitizedData.types = Object.assign({ EIP712Domain: [] }, sanitizedData.types)
+    }
     return sanitizedData
   },
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,10 @@ const TypedDataUtils = {
           value = ethUtil.sha3(this.encodeData(field.type, value, types))
           encodedValues.push(value)
         } else if (field.type.lastIndexOf(']') === field.type.length - 1) {
-          throw new Error('Arrays currently unimplemented in encodeData')
+          encodedTypes.push('bytes32')
+          const parsedType = field.type.slice(0, field.type.lastIndexOf('['))
+          value = ethUtil.sha3(value.map(item => this.encodeData(parsedType, item, types)).join(''))
+          encodedValues.push(value)
         } else {
           encodedTypes.push(field.type)
           encodedValues.push(value)
@@ -148,7 +151,7 @@ const TypedDataUtils = {
    * @returns {string} - sha3 hash of the resulting signed message
    */
   sign (typedData) {
-    sanitizedData = this.sanitizeData(typedData)
+    const sanitizedData = this.sanitizeData(typedData)
     const parts = [Buffer.from('1901', 'hex')]
     parts.push(this.hashStruct('EIP712Domain', sanitizedData.domain, sanitizedData.types))
     parts.push(this.hashStruct(sanitizedData.primaryType, sanitizedData.message, sanitizedData.types))

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ const typedData = {
       ],
       Mail: [
           { name: 'from', type: 'Person' },
-          { name: 'to', type: 'Person' },
+          { name: 'to', type: 'Person[]' },
           { name: 'contents', type: 'string' }
       ],
   },
@@ -32,10 +32,10 @@ const typedData = {
           name: 'Cow',
           wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
       },
-      to: {
+      to: [{
           name: 'Bob',
           wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
-      },
+      }],
       contents: 'Hello, Bob!',
   },
 }
@@ -318,17 +318,17 @@ test('signedTypeData', (t) => {
   const sig = sigUtil.signTypedData(privateKey, { data: typedData })
 
   t.equal(utils.encodeType('Mail', typedData.types),
-    'Mail(Person from,Person to,string contents)Person(string name,address wallet)')
+    'Mail(Person from,Person[] to,string contents)Person(string name,address wallet)')
   t.equal(ethUtil.bufferToHex(utils.hashType('Mail', typedData.types)),
-    '0xa0cedeb2dc280ba39b857546d74f5549c3a1d7bdc2dd96bf881f76108e23dac2')
+    '0xdd57d9596af52b430ced3d5b52d4e3d5dccfdf3e0572db1dcf526baad311fbd1')
   t.equal(ethUtil.bufferToHex(utils.encodeData(typedData.primaryType, typedData.message, typedData.types)),
-    '0xa0cedeb2dc280ba39b857546d74f5549c3a1d7bdc2dd96bf881f76108e23dac2fc71e5fa27ff56c350aa531bc129ebdf613b772b6604664f5d8dbe21b85eb0c8cd54f074a4af31b4411ff6a60c9719dbd559c221c8ac3492d9d872b041d703d1b5aadf3154a261abdd9086fc627b61efca26ae5702701d05cd2305f7c52a2fc8')
+    '0xdd57d9596af52b430ced3d5b52d4e3d5dccfdf3e0572db1dcf526baad311fbd1fc71e5fa27ff56c350aa531bc129ebdf613b772b6604664f5d8dbe21b85eb0c872ea07cf404427eb52aed74d9998e238434f046d95c4ff7802d628628bf77a16b5aadf3154a261abdd9086fc627b61efca26ae5702701d05cd2305f7c52a2fc8')
   t.equal(ethUtil.bufferToHex(utils.hashStruct(typedData.primaryType, typedData.message, typedData.types)),
-    '0xc52c0ee5d84264471806290a3f2c4cecfc5490626bf912d01f240d7a274b371e')
+    '0x74d81a21341d4ee3434cd75927bce467aeba1fa381760f07f95d9daee6f21e2b')
   t.equal(ethUtil.bufferToHex(utils.hashStruct('EIP712Domain', typedData.domain, typedData.types)),
     '0xf2cee375fa42b42143804025fc449deafd50cc031ca257e0b194a650a912090f')
   t.equal(ethUtil.bufferToHex(utils.sign(typedData)),
-    '0xbe609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2')
+    '0x89f2c3d1cb4d1aa3e9c41f664a590fe73bfccdf8be1f8e03b79f5c099a0bd090')
   t.equal(ethUtil.bufferToHex(address), '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826')
-  t.equal(sig, '0x4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d07299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b915621c')
+  t.equal(sig, '0x62c03af2a2efc2fc5023a11f6b1fffc01d27aad85bfc88dd2ba9aee8cb8b2cec450d8ce8999ccc65327e40dc3d96286b7d118ba087b7ce40fbdb8de4f6bc0c0d1c')
 })


### PR DESCRIPTION
The original implementation of `signTypedData` omitted array support. This pull request remedies this by adding array support as per [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md) along with updated tests.