### PR TITLE
Adding safely encrypt and decrypt with padding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+    },
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
@@ -62,6 +67,15 @@
       "integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
       "requires": {
         "js-sha3": "^0.3.1"
+      }
+    },
+    "buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-xor": {
@@ -311,6 +325,11 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "ieee754": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
     },
     "inflight": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/MetaMask/eth-sig-util#readme",
   "dependencies": {
+    "buffer": "^5.2.1",
     "elliptic": "^6.4.0",
     "ethereumjs-abi": "0.6.5",
     "ethereumjs-util": "^5.1.1",

--- a/test/index.js
+++ b/test/index.js
@@ -331,7 +331,7 @@ test("Getting bob's encryptionPublicKey", async t => {
 
 //encryption test
 test("Alice encrypts message with bob's encryptionPublicKey", async t => {
-  
+
 
   t.plan(4);
 
@@ -348,6 +348,39 @@ test("Alice encrypts message with bob's encryptionPublicKey", async t => {
   t.ok(result.ephemPublicKey);
   t.ok(result.ciphertext);
 
+});
+
+// safe encryption test
+test("Alice encryptsSafely message with bob's encryptionPublicKey", async t => {
+  t.plan(5);
+  const VERSION = 'x25519-xsalsa20-poly1305';
+  const result = await sigUtil.encryptSafely(
+     bob.encryptionPublicKey,
+     secretMessage,
+     VERSION
+  );
+
+  console.log("RESULT", result)
+
+  t.equals(result.version,VERSION);
+  t.ok(result.nonce);
+  t.ok(result.ephemPublicKey);
+  t.ok(result.ciphertext);
+  t.ok(result.ciphertext.length > 1048)
+});
+
+// safe decryption test
+test("Bob decryptSafely message that Alice encryptSafely for him", async t => {
+  t.plan(1);
+  const VERSION = 'x25519-xsalsa20-poly1305';
+  const result = await sigUtil.encryptSafely(
+     bob.encryptionPublicKey,
+     secretMessage,
+     VERSION
+  );
+
+  const plaintext = sigUtil.decryptSafely(result, bob.ethereumPrivateKey);
+  t.equal(plaintext, secretMessage.data);
 });
 
 // decryption test


### PR DESCRIPTION
Direct use of the `encrypt` method will expose the length of the input message.  The plaintext length can easly be predicted within a few bytes simply by using the ciphertext byte length.

The `encryptSafely` will pad the input into chunks of around 2048 bytes.  Thus the ciphertext length will only expose the nearest 2048 bytse.

Basic test have been added.
