### PR TITLE
Refactor buffer constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -415,7 +415,7 @@ function padWithZeroes (number, length) {
 
 //converts hex strings to the Uint8Array format used by nacl
 function nacl_decodeHex(msgHex) {
-  var msgBase64 = (new Buffer(msgHex, 'hex')).toString('base64');
+  var msgBase64 = (Buffer.from(msgHex, 'hex')).toString('base64');
   return nacl.util.decodeBase64(msgBase64);
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -77,7 +77,7 @@ test('personalSign and recover', function (t) {
   const address = '0x29c76e6ad8f28bb1004902578fb108c507be341b'
   console.log('for address ' + address)
   const privKeyHex = '4af1bceebf7f3634ec3cff8a2c38e51178d5d4ce585c52d6043e5e2cc3418bb0'
-  const privKey = new Buffer(privKeyHex, 'hex')
+  const privKey = Buffer.from(privKeyHex, 'hex')
   const message = 'Hello, world!'
   const msgParams = { data: message }
 
@@ -93,7 +93,7 @@ test('personalSign and extractPublicKey', function (t) {
   const privKeyHex = '4af1bceebf7f3634ec3cff8a2c38e51178d5d4ce585c52d6043e5e2cc3418bb0'
   const pubKeyHex = '0x9e9e45b2ec5f070b4e26f57c7fedf647afa7a03e894789816fbd12fedc5acd79d0dfeea925688e177caccb8f5e09f0c289bbcfc7adb98d76f5f8c5259478903a'
 
-  const privKey = new Buffer(privKeyHex, 'hex')
+  const privKey = Buffer.from(privKeyHex, 'hex')
   const message = 'Hello, world!'
   const msgParams = { data: message }
 
@@ -255,7 +255,7 @@ signatureTest({
   message: '0x68656c6c6f20776f726c64',
   signature: '0xce909e8ea6851bc36c007a0072d0524b07a3ff8d4e623aca4c71ca8e57250c4d0a3fc38fa8fbaaa81ead4b9f6bd03356b6f8bf18bccad167d78891636e1d69561b',
   addressHex: '0xbe93f9bacbcffc8ee6663f2647917ed7a20a57bb',
-  privateKey: new Buffer('6969696969696969696969696969696969696969696969696969696969696969', 'hex'),
+  privateKey: Buffer.from('6969696969696969696969696969696969696969696969696969696969696969', 'hex'),
 })
 
 signatureTest({
@@ -264,7 +264,7 @@ signatureTest({
   message: '0x0cc175b9c0f1b6a831c399e26977266192eb5ffee6ae2fec3ad71c777531578f',
   signature: '0x9ff8350cc7354b80740a3580d0e0fd4f1f02062040bc06b893d70906f8728bb5163837fd376bf77ce03b55e9bd092b32af60e86abce48f7b8d3539988ee5a9be1c',
   addressHex: '0xbe93f9bacbcffc8ee6663f2647917ed7a20a57bb',
-  privateKey: new Buffer('6969696969696969696969696969696969696969696969696969696969696969', 'hex'),
+  privateKey: Buffer.from('6969696969696969696969696969696969696969696969696969696969696969', 'hex'),
 })
 
 signatureTest({
@@ -275,7 +275,7 @@ signatureTest({
   message: '0x0cc175b9c0f1b6a831c399e26977266192eb5ffee6ae2fec3ad71c777531578f',
   signature: '0xa2870db1d0c26ef93c7b72d2a0830fa6b841e0593f7186bc6c7cc317af8cf3a42fda03bd589a49949aa05db83300cdb553116274518dbe9d90c65d0213f4af491b',
   addressHex: '0xe0da1edcea030875cd0f199d96eb70f6ab78faf2',
-  privateKey: new Buffer('4545454545454545454545454545454545454545454545454545454545454545', 'hex'),
+  privateKey: Buffer.from('4545454545454545454545454545454545454545454545454545454545454545', 'hex'),
 })
 
 function signatureTest(opts) {

--- a/utils/eccrypto-lite.js
+++ b/utils/eccrypto-lite.js
@@ -12,14 +12,14 @@ module.exports = {
 		const twoStripped = privateKey.replace(/^.{2}/g, '');
 		console.log(twoStripped)
 		const encryptedBuffer = {
-        iv: new Buffer(encrypted.iv, 'hex'),
-        ephemPublicKey: new Buffer(encrypted.ephemPublicKey, 'hex'),
-        ciphertext: new Buffer(encrypted.ciphertext, 'hex'),
-        mac: new Buffer(encrypted.mac, 'hex')
+        iv: Buffer.from(encrypted.iv, 'hex'),
+        ephemPublicKey: Buffer.from(encrypted.ephemPublicKey, 'hex'),
+        ciphertext: Buffer.from(encrypted.ciphertext, 'hex'),
+        mac: Buffer.from(encrypted.mac, 'hex')
     };
 
     const decryptedBuffer = await decrypt(
-        new Buffer(twoStripped, 'hex'),
+        Buffer.from(twoStripped, 'hex'),
         encryptedBuffer
     );
     return decryptedBuffer.toString();
@@ -29,7 +29,7 @@ module.exports = {
 	encryptWithPublicKey: async function(receiverPublicKey, payload) {
 		const pubString = '04' + receiverPublicKey;
 		const encryptedBuffers = await encrypt(
-        new Buffer(pubString, 'hex'),
+        Buffer.from(pubString, 'hex'),
         Buffer(payload)
     );
 		const encrypted = {
@@ -51,12 +51,12 @@ function assert(condition, message) {
 function randomBytes(size) {
   var arr = new Uint8Array(size);
   global.crypto.getRandomValues(arr);
-  return new Buffer(arr);
+  return Buffer.from(arr);
 }
 
 function sha512(msg) {
   return subtle.digest({name: "SHA-512"}, msg).then(function(hash) {
-    return new Buffer(new Uint8Array(hash));
+    return Buffer.from(new Uint8Array(hash));
   });
 }
 
@@ -68,7 +68,7 @@ function getAes(op) {
       var encAlgorithm = {name: "AES-CBC", iv: iv};
       return subtle[op](encAlgorithm, cryptoKey, data);
     }).then(function(result) {
-      return new Buffer(new Uint8Array(result));
+      return Buffer.from(new Uint8Array(result));
     });
   };
 }
@@ -82,7 +82,7 @@ function hmacSha256Sign(key, msg) {
   return keyp.then(function(cryptoKey) {
     return subtle.sign(algorithm, cryptoKey, msg);
   }).then(function(sig) {
-    return new Buffer(new Uint8Array(sig));
+    return Buffer.from(new Uint8Array(sig));
   });
 }
 
@@ -96,7 +96,7 @@ function hmacSha256Verify(key, msg, sig) {
 
 var getPublic = exports.getPublic = function(privateKey) {
   assert(privateKey.length === 32, "Bad private key");
-  return new Buffer(ec.keyFromPrivate(privateKey).getPublic("arr"));
+  return Buffer.from(ec.keyFromPrivate(privateKey).getPublic("arr"));
 };
 
 
@@ -110,7 +110,7 @@ var derive = exports.derive = function(privateKeyA, publicKeyB) {
     var keyA = ec.keyFromPrivate(privateKeyA);
     var keyB = ec.keyFromPublic(publicKeyB);
     var Px = keyA.derive(keyB.getPublic());  // BN instance
-    resolve(new Buffer(Px.toArray()));
+    resolve(Buffer.from(Px.toArray()));
   });
 };
 
@@ -162,6 +162,6 @@ const decrypt = function(privateKey, opts) {
     assert(macGood, "Bad MAC");
     return aesCbcDecrypt(opts.iv, encryptionKey, opts.ciphertext);
   }).then(function(msg) {
-    return new Buffer(new Uint8Array(msg));
+    return Buffer.from(new Uint8Array(msg));
   });
 };


### PR DESCRIPTION
This PR replaces all `new Buffer` with `Buffer.from`. We should not use Buffer constructor which is deprecated and unsafe.

The behavior of new Buffer() is different depending on the type of the first argument, security and reliability issues can be inadvertently introduced into applications when argument validation or Buffer initialization is not performed.

To make the creation of Buffer instances more reliable and less error-prone, the various forms of the new Buffer() constructor have been deprecated and replaced by separate Buffer.from(), Buffer.alloc(), and Buffer.allocUnsafe() methods.

Check this out: https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe
https://github.com/nodejs/Release#end-of-life-releases