### PR TITLE
Support ERC191 v0 signatures

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { Buffer } = require('buffer');
+// const { Buffer } = require('buffer');
 const ethUtil = require('ethereumjs-util');
 const ethAbi = require('ethereumjs-abi');
 const nacl = require('tweetnacl');


### PR DESCRIPTION
Companion PR for [#5884 on `metamask-extension`](https://github.com/MetaMask/metamask-extension/pull/5884) adding support for [ERC191 v0](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-191.md) signatures via a new `eth_signTypedData_v0` RPC call.

Note: I was getting the error below when building the Metamask extension with any non-NPM installed version of this library (even without making any changes). To get around it I commented out the `Buffer` redefinition in L1. Am I missing something? Maybe this is some kind of node versioning/build system/NPM issue?

```
Error: Parsing file /Users/noahzinsmeister/Documents/github/metamask-extension/node_modules/eth-sig-util/index.js: Identifier 'Buffer' has already been declared (2:8)
    at Deps.parseDeps (/Users/noahzinsmeister/Documents/github/metamask-extension/node_modules/module-deps/index.js:506:28)
```