### PR TITLE
Allow `primaryType` to be `EIP712Domain`

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,9 @@ const TypedDataUtils = {
     const sanitizedData = this.sanitizeData(typedData)
     const parts = [Buffer.from('1901', 'hex')]
     parts.push(this.hashStruct('EIP712Domain', sanitizedData.domain, sanitizedData.types))
-    parts.push(this.hashStruct(sanitizedData.primaryType, sanitizedData.message, sanitizedData.types))
+    if (sanitizedData.primaryType !== 'EIP712Domain') {
+      parts.push(this.hashStruct(sanitizedData.primaryType, sanitizedData.message, sanitizedData.types))
+    }
     return ethUtil.sha3(Buffer.concat(parts))
   },
 }


### PR DESCRIPTION
Allow less-complex, and EIP712 compliant domain hash production without the force use of a second primary type.

This would greatly lessen the gas overhead of verifying EIP712 payloads and deployment cost for highly gas-sensitive deployments.