### PR TITLE
signTypedData for arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,12 @@ const TypedDataUtils = {
 
     if(useV4) {
       const encodeField = (name, type, value) => {
+        if (types[type] !== undefined) {
+          return ['bytes32', value == null ?
+            '0x0000000000000000000000000000000000000000000000000000000000000000' :
+            ethUtil.sha3(this.encodeData(type, value, types, useV4))]
+        }
+
         if(value === undefined)
           throw new Error(`missing value for field ${name} of type ${type}`)
 
@@ -59,10 +65,6 @@ const TypedDataUtils = {
             value = Buffer.from(value, 'utf8')
           }
           return ['bytes32', ethUtil.sha3(value)]
-        }
-
-        if (types[type] !== undefined) {
-          return ['bytes32', ethUtil.sha3(this.encodeData(type, value, types, useV4))]
         }
 
         if (type.lastIndexOf(']') === type.length - 1) {

--- a/index.js
+++ b/index.js
@@ -116,6 +116,7 @@ const TypedDataUtils = {
    * @returns {Array} - Set of all types found in the type definition
    */
   findTypeDependencies (primaryType, types, results = []) {
+    primaryType = primaryType.match(/^\w*/)[0]
     if (results.includes(primaryType) || types[primaryType] === undefined) { return results }
     results.push(primaryType)
     for (const field of types[primaryType]) {

--- a/test/index.js
+++ b/test/index.js
@@ -2,44 +2,6 @@ const test = require('tape')
 const sigUtil = require('../')
 const ethUtil = require('ethereumjs-util')
 
-const typedData = {
-  types: {
-      EIP712Domain: [
-          { name: 'name', type: 'string' },
-          { name: 'version', type: 'string' },
-          { name: 'chainId', type: 'uint256' },
-          { name: 'verifyingContract', type: 'address' },
-      ],
-      Person: [
-          { name: 'name', type: 'string' },
-          { name: 'wallet', type: 'address' }
-      ],
-      Mail: [
-          { name: 'from', type: 'Person' },
-          { name: 'to', type: 'Person[]' },
-          { name: 'contents', type: 'string' }
-      ],
-  },
-  primaryType: 'Mail',
-  domain: {
-      name: 'Ether Mail',
-      version: '1',
-      chainId: 1,
-      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
-  },
-  message: {
-      from: {
-          name: 'Cow',
-          wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
-      },
-      to: [{
-          name: 'Bob',
-          wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
-      }],
-      contents: 'Hello, Bob!',
-  },
-}
-
 test('normalize address lower cases', function (t) {
   t.plan(1)
   const initial = '0xA06599BD35921CfB5B71B4BE3869740385b0B306'
@@ -447,6 +409,45 @@ test("Decryption fails because you are not the recipient", t => {
 
 test('signedTypeData', (t) => {
   t.plan(8)
+
+  const typedData = {
+    types: {
+        EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' },
+        ],
+        Person: [
+            { name: 'name', type: 'string' },
+            { name: 'wallet', type: 'address' }
+        ],
+        Mail: [
+            { name: 'from', type: 'Person' },
+            { name: 'to', type: 'Person[]' },
+            { name: 'contents', type: 'string' }
+        ],
+    },
+    domain: {
+        name: 'Ether Mail',
+        version: '1',
+        chainId: 1,
+        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+    },
+    primaryType: 'Mail',
+    message: {
+        from: {
+            name: 'Cow',
+            wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+        },
+        to: [{
+            name: 'Bob',
+            wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+        }],
+        contents: 'Hello, Bob!',
+    },
+  }
+
   const utils = sigUtil.TypedDataUtils
   const privateKey = ethUtil.sha3('cow')
   const address = ethUtil.privateToAddress(privateKey)

--- a/test/index.js
+++ b/test/index.js
@@ -408,6 +408,68 @@ test("Decryption fails because you are not the recipient", t => {
 });
 
 test('signedTypeData', (t) => {
+  t.plan(8)
+
+  const typedData = {
+    types: {
+        EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' },
+        ],
+        Person: [
+            { name: 'name', type: 'string' },
+            { name: 'wallet', type: 'address' }
+        ],
+        Mail: [
+            { name: 'from', type: 'Person' },
+            { name: 'to', type: 'Person' },
+            { name: 'contents', type: 'string' }
+        ],
+    },
+    primaryType: 'Mail',
+    domain: {
+        name: 'Ether Mail',
+        version: '1',
+        chainId: 1,
+        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+    },
+    message: {
+        from: {
+            name: 'Cow',
+            wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+        },
+        to: {
+            name: 'Bob',
+            wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+        },
+        contents: 'Hello, Bob!',
+    },
+  }
+
+  const utils = sigUtil.TypedDataUtils
+  const privateKey = ethUtil.sha3('cow')
+  const address = ethUtil.privateToAddress(privateKey)
+  const sig = sigUtil.signTypedData(privateKey, { data: typedData })
+
+  t.equal(utils.encodeType('Mail', typedData.types),
+    'Mail(Person from,Person to,string contents)Person(string name,address wallet)')
+  t.equal(ethUtil.bufferToHex(utils.hashType('Mail', typedData.types)),
+    '0xa0cedeb2dc280ba39b857546d74f5549c3a1d7bdc2dd96bf881f76108e23dac2')
+  t.equal(ethUtil.bufferToHex(utils.encodeData(typedData.primaryType, typedData.message, typedData.types)),
+    '0xa0cedeb2dc280ba39b857546d74f5549c3a1d7bdc2dd96bf881f76108e23dac2fc71e5fa27ff56c350aa531bc129ebdf613b772b6604664f5d8dbe21b85eb0c8cd54f074a4af31b4411ff6a60c9719dbd559c221c8ac3492d9d872b041d703d1b5aadf3154a261abdd9086fc627b61efca26ae5702701d05cd2305f7c52a2fc8')
+  t.equal(ethUtil.bufferToHex(utils.hashStruct(typedData.primaryType, typedData.message, typedData.types)),
+    '0xc52c0ee5d84264471806290a3f2c4cecfc5490626bf912d01f240d7a274b371e')
+  t.equal(ethUtil.bufferToHex(utils.hashStruct('EIP712Domain', typedData.domain, typedData.types)),
+    '0xf2cee375fa42b42143804025fc449deafd50cc031ca257e0b194a650a912090f')
+  t.equal(ethUtil.bufferToHex(utils.sign(typedData)),
+    '0xbe609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2')
+  t.equal(ethUtil.bufferToHex(address), '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826')
+  t.equal(sig, '0x4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d07299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b915621c')
+})
+
+test('signedTypeData_v4', (t) => {
   t.plan(15)
 
   const typedData = {
@@ -513,7 +575,7 @@ test('signedTypeData', (t) => {
   const address = ethUtil.privateToAddress(privateKey)
   t.equal(ethUtil.bufferToHex(address), '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826')
 
-  const sig = sigUtil.signTypedData(privateKey, { data: typedData })
+  const sig = sigUtil.signTypedData_v4(privateKey, { data: typedData })
 
   t.equal(sig, '0x65cbd956f2fae28a601bebc9b906cea0191744bd4c4247bcd27cd08f8eb6b71c78efdf7a31dc9abee78f492292721f362d296cf86b4538e07b51303b67f749061b')
 })

--- a/test/index.js
+++ b/test/index.js
@@ -408,7 +408,7 @@ test("Decryption fails because you are not the recipient", t => {
 });
 
 test('signedTypeData', (t) => {
-  t.plan(14)
+  t.plan(15)
 
   const typedData = {
     types: {
@@ -426,6 +426,10 @@ test('signedTypeData', (t) => {
             { name: 'from', type: 'Person' },
             { name: 'to', type: 'Person[]' },
             { name: 'contents', type: 'string' },
+        ],
+        Group: [
+            { name: 'name', type: 'string' },
+            { name: 'members', type: 'Person[]' },
         ],
     },
     domain: {
@@ -456,6 +460,9 @@ test('signedTypeData', (t) => {
   }
 
   const utils = sigUtil.TypedDataUtils
+
+  t.equal(utils.encodeType('Group', typedData.types),
+    'Group(string name,Person[] members)Person(string name,address[] wallets)')
 
   t.equal(utils.encodeType('Person', typedData.types),
     'Person(string name,address[] wallets)')

--- a/test/index.js
+++ b/test/index.js
@@ -579,3 +579,99 @@ test('signedTypeData_v4', (t) => {
 
   t.equal(sig, '0x65cbd956f2fae28a601bebc9b906cea0191744bd4c4247bcd27cd08f8eb6b71c78efdf7a31dc9abee78f492292721f362d296cf86b4538e07b51303b67f749061b')
 })
+
+test('signedTypeData_v4 with recursive types', (t) => {
+  t.plan(12)
+
+  const typedData = {
+    types: {
+        EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' },
+        ],
+        Person: [
+            { name: 'name', type: 'string' },
+            { name: 'mother', type: 'Person' },
+            { name: 'father', type: 'Person' },
+        ]
+    },
+    domain: {
+        name: 'Family Tree',
+        version: '1',
+        chainId: 1,
+        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+    },
+    primaryType: 'Person',
+    message: {
+        name: 'Jon',
+        mother: {
+          name: 'Lyanna',
+          father: {
+            name: 'Rickard',
+          },
+        },
+        father: {
+          name: 'Rhaegar',
+          father: {
+            name: 'Aeris II',
+          }
+        },
+    },
+  }
+
+  const utils = sigUtil.TypedDataUtils
+
+  t.equal(utils.encodeType('Person', typedData.types),
+    'Person(string name,Person mother,Person father)')
+
+  t.equal(ethUtil.bufferToHex(utils.hashType('Person', typedData.types)),
+    '0x7c5c8e90cb92c8da53b893b24962513be98afcf1b57b00327ae4cc14e3a64116')
+
+  t.equal(ethUtil.bufferToHex(utils.encodeData('Person', typedData.message.mother, typedData.types)),
+    '0x' + [
+      '7c5c8e90cb92c8da53b893b24962513be98afcf1b57b00327ae4cc14e3a64116',
+      'afe4142a2b3e7b0503b44951e6030e0e2c5000ef83c61857e2e6003e7aef8570',
+      '0000000000000000000000000000000000000000000000000000000000000000',
+      '88f14be0dd46a8ec608ccbff6d3923a8b4e95cdfc9648f0db6d92a99a264cb36',
+    ].join('')
+  )
+  t.equal(ethUtil.bufferToHex(utils.hashStruct('Person', typedData.message.mother, typedData.types)),
+    '0x9ebcfbf94f349de50bcb1e3aa4f1eb38824457c99914fefda27dcf9f99f6178b')
+
+  t.equal(ethUtil.bufferToHex(utils.encodeData('Person', typedData.message.father, typedData.types)),
+    '0x' + [
+      '7c5c8e90cb92c8da53b893b24962513be98afcf1b57b00327ae4cc14e3a64116',
+      'b2a7c7faba769181e578a391a6a6811a3e84080c6a3770a0bf8a856dfa79d333',
+      '0000000000000000000000000000000000000000000000000000000000000000',
+      '02cc7460f2c9ff107904cff671ec6fee57ba3dd7decf999fe9fe056f3fd4d56e',
+    ].join('')
+  )
+  t.equal(ethUtil.bufferToHex(utils.hashStruct('Person', typedData.message.father, typedData.types)),
+    '0xb852e5abfeff916a30cb940c4e24c43cfb5aeb0fa8318bdb10dd2ed15c8c70d8')
+
+  t.equal(ethUtil.bufferToHex(utils.encodeData(typedData.primaryType, typedData.message, typedData.types)),
+    '0x' + [
+      '7c5c8e90cb92c8da53b893b24962513be98afcf1b57b00327ae4cc14e3a64116',
+      'e8d55aa98b6b411f04dbcf9b23f29247bb0e335a6bc5368220032fdcb9e5927f',
+      '9ebcfbf94f349de50bcb1e3aa4f1eb38824457c99914fefda27dcf9f99f6178b',
+      'b852e5abfeff916a30cb940c4e24c43cfb5aeb0fa8318bdb10dd2ed15c8c70d8',
+    ].join('')
+  )
+  t.equal(ethUtil.bufferToHex(utils.hashStruct(typedData.primaryType, typedData.message, typedData.types)),
+    '0xfdc7b6d35bbd81f7fa78708604f57569a10edff2ca329c8011373f0667821a45')
+  t.equal(ethUtil.bufferToHex(utils.hashStruct('EIP712Domain', typedData.domain, typedData.types)),
+    '0xfacb2c1888f63a780c84c216bd9a81b516fc501a19bae1fc81d82df590bbdc60')
+  t.equal(ethUtil.bufferToHex(utils.sign(typedData)),
+    '0x807773b9faa9879d4971b43856c4d60c2da15c6f8c062bd9d33afefb756de19c')
+
+  const privateKey = ethUtil.sha3('dragon')
+
+  const address = ethUtil.privateToAddress(privateKey)
+  t.equal(ethUtil.bufferToHex(address), '0x065a687103c9f6467380bee800ecd70b17f6b72f')
+
+  const sig = sigUtil.signTypedData_v4(privateKey, { data: typedData })
+
+  t.equal(sig, '0xf2ec61e636ff7bb3ac8bc2a4cc2c8b8f635dd1b2ec8094c963128b358e79c85c5ca6dd637ed7e80f0436fe8fce39c0e5f2082c9517fe677cc2917dcd6c84ba881c')
+})


### PR DESCRIPTION
This builds on @bitpshr's previous work on signTypedData, adding support for the following:

Arrays of atomic types have been encoded as a hash of its contents, where its contents are word-aligned according to the type.

Arrays of dynamic types have been encoded as a hash of each element's hash.

Arrays of structs retain their encoding as a hash of its contents' concatenated hashStructs.

Arrays of arrays are encoded recursively, as a hash of the contained arrays' hash encodings concatenated.