### PR TITLE
Create generic typed sign methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,6 +272,8 @@ module.exports = {
     return ethUtil.bufferToHex(hashBuffer)
   },
 
+
+
   signTypedDataLegacy: function (privateKey, msgParams) {
     const msgHash = typedSignatureHash(msgParams.data)
     const sig = ethUtil.ecsign(msgHash, privateKey)
@@ -405,6 +407,34 @@ module.exports = {
     var privateKeyUint8Array = nacl_decodeHex(privateKey)
     var encryptionPublicKey = nacl.box.keyPair.fromSecretKey(privateKeyUint8Array).publicKey
     return nacl.util.encodeBase64(encryptionPublicKey)
+  },
+
+
+  /**
+   * A generic entry point for all typed data methods to be passed, includes a version parameter.
+   */
+  signTypedMessage: function (privateKey, msgParams, version = 'V4') {
+    switch (version) {
+      case 'V1':
+        return this.signTypedDataLegacy(privateKey, msgParams)
+      case 'V3':
+        return this.signTypedData(privateKey, msgParams)
+      case 'V4':
+      default:
+        return this.signTypedData_v4(privateKey, msgParams)
+    }
+  },
+
+  recoverTypedMessage: function (msgParams, version = 'V4') {
+    switch (version) {
+      case 'V1':
+        return this.recoverTypedSignatureLegacy(msgParams)
+      case 'V3':
+        return this.recoverTypedSignature(msgParams)
+      case 'V4':
+      default:
+        return this.recoverTypedSignature_v4(msgParams)
+    }
   },
 
   signTypedData: function (privateKey, msgParams) {

--- a/index.js
+++ b/index.js
@@ -272,8 +272,6 @@ module.exports = {
     return ethUtil.bufferToHex(hashBuffer)
   },
 
-
-
   signTypedDataLegacy: function (privateKey, msgParams) {
     const msgHash = typedSignatureHash(msgParams.data)
     const sig = ethUtil.ecsign(msgHash, privateKey)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-sig-util",
-  "version": "2.4.4",
+  "version": "2.5.0",
   "description": "A few useful functions for signing ethereum data",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -90,6 +90,30 @@ test('signTypedDataLegacy and recoverTypedSignatureLegacy - single message', fun
   t.end()
 })
 
+test('signTypedDataLegacy as v1 and recoverTypedSignatureLegacy - single message', function (t) {
+  const address = '0x29c76e6ad8f28bb1004902578fb108c507be341b'
+  const privKeyHex = '4af1bceebf7f3634ec3cff8a2c38e51178d5d4ce585c52d6043e5e2cc3418bb0'
+
+  const privKey = Buffer.from(privKeyHex, 'hex')
+
+  const typedData = [
+    {
+      type: 'string',
+      name: 'message',
+      value: 'Hi, Alice!'
+    }
+  ]
+
+  const msgParams = { data: typedData }
+
+  const signature = sigUtil.signTypedMessage(privKey, msgParams, 'V1')
+  const recovered = sigUtil.recoverTypedMessage({ data: msgParams.data, sig: signature }, 'V1')
+  t.equal(signature, '0x49e75d475d767de7fcc67f521e0d86590723d872e6111e51c393e8c1e2f21d032dfaf5833af158915f035db6af4f37bf2d5d29781cd81f28a44c5cb4b9d241531b', 'Signature matches test value.')
+
+  t.equal(address, recovered)
+  t.end()
+})
+
 test('signTypedDataLegacy and recoverTypedSignatureLegacy - multiple messages', function (t) {
   t.plan(1)
   const address = '0x29c76e6ad8f28bb1004902578fb108c507be341b'
@@ -470,6 +494,180 @@ test('signedTypeData', (t) => {
   t.equal(sig, '0x4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d07299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b915621c')
 })
 
+test('signedTypeData with V3 string', (t) => {
+  t.plan(8)
+
+  const typedData = {
+    types: {
+        EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' },
+        ],
+        Person: [
+            { name: 'name', type: 'string' },
+            { name: 'wallet', type: 'address' }
+        ],
+        Mail: [
+            { name: 'from', type: 'Person' },
+            { name: 'to', type: 'Person' },
+            { name: 'contents', type: 'string' }
+        ],
+    },
+    primaryType: 'Mail',
+    domain: {
+        name: 'Ether Mail',
+        version: '1',
+        chainId: 1,
+        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+    },
+    message: {
+        from: {
+            name: 'Cow',
+            wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+        },
+        to: {
+            name: 'Bob',
+            wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+        },
+        contents: 'Hello, Bob!',
+    },
+  }
+
+  const utils = sigUtil.TypedDataUtils
+  const privateKey = ethUtil.sha3('cow')
+  const address = ethUtil.privateToAddress(privateKey)
+  const sig = sigUtil.signTypedMessage(privateKey, { data: typedData }, 'V3')
+
+  t.equal(utils.encodeType('Mail', typedData.types),
+    'Mail(Person from,Person to,string contents)Person(string name,address wallet)')
+  t.equal(ethUtil.bufferToHex(utils.hashType('Mail', typedData.types)),
+    '0xa0cedeb2dc280ba39b857546d74f5549c3a1d7bdc2dd96bf881f76108e23dac2')
+  t.equal(ethUtil.bufferToHex(utils.encodeData(typedData.primaryType, typedData.message, typedData.types)),
+    '0xa0cedeb2dc280ba39b857546d74f5549c3a1d7bdc2dd96bf881f76108e23dac2fc71e5fa27ff56c350aa531bc129ebdf613b772b6604664f5d8dbe21b85eb0c8cd54f074a4af31b4411ff6a60c9719dbd559c221c8ac3492d9d872b041d703d1b5aadf3154a261abdd9086fc627b61efca26ae5702701d05cd2305f7c52a2fc8')
+  t.equal(ethUtil.bufferToHex(utils.hashStruct(typedData.primaryType, typedData.message, typedData.types)),
+    '0xc52c0ee5d84264471806290a3f2c4cecfc5490626bf912d01f240d7a274b371e')
+  t.equal(ethUtil.bufferToHex(utils.hashStruct('EIP712Domain', typedData.domain, typedData.types)),
+    '0xf2cee375fa42b42143804025fc449deafd50cc031ca257e0b194a650a912090f')
+  t.equal(ethUtil.bufferToHex(utils.sign(typedData)),
+    '0xbe609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2')
+  t.equal(ethUtil.bufferToHex(address), '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826')
+  t.equal(sig, '0x4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d07299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b915621c')
+})
+
+test('signedTypeData_v4', (t) => {
+  t.plan(15)
+
+  const typedData = {
+    types: {
+        EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' },
+        ],
+        Person: [
+            { name: 'name', type: 'string' },
+            { name: 'wallets', type: 'address[]' },
+        ],
+        Mail: [
+            { name: 'from', type: 'Person' },
+            { name: 'to', type: 'Person[]' },
+            { name: 'contents', type: 'string' },
+        ],
+        Group: [
+            { name: 'name', type: 'string' },
+            { name: 'members', type: 'Person[]' },
+        ],
+    },
+    domain: {
+        name: 'Ether Mail',
+        version: '1',
+        chainId: 1,
+        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+    },
+    primaryType: 'Mail',
+    message: {
+        from: {
+            name: 'Cow',
+            wallets: [
+              '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+              '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
+            ],
+        },
+        to: [{
+            name: 'Bob',
+            wallets: [
+              '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+              '0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57',
+              '0xB0B0b0b0b0b0B000000000000000000000000000'
+            ]
+        }],
+        contents: 'Hello, Bob!',
+    },
+  }
+
+  const utils = sigUtil.TypedDataUtils
+
+  t.equal(utils.encodeType('Group', typedData.types),
+    'Group(string name,Person[] members)Person(string name,address[] wallets)')
+
+  t.equal(utils.encodeType('Person', typedData.types),
+    'Person(string name,address[] wallets)')
+  t.equal(ethUtil.bufferToHex(utils.hashType('Person', typedData.types)),
+    '0xfabfe1ed996349fc6027709802be19d047da1aa5d6894ff5f6486d92db2e6860')
+
+  t.equal(ethUtil.bufferToHex(utils.encodeData('Person', typedData.message.from, typedData.types)),
+    '0x' + [
+      'fabfe1ed996349fc6027709802be19d047da1aa5d6894ff5f6486d92db2e6860',
+      '8c1d2bd5348394761719da11ec67eedae9502d137e8940fee8ecd6f641ee1648',
+      '8a8bfe642b9fc19c25ada5dadfd37487461dc81dd4b0778f262c163ed81b5e2a',
+    ].join('')
+  )
+  t.equal(ethUtil.bufferToHex(utils.hashStruct('Person', typedData.message.from, typedData.types)),
+    '0x9b4846dd48b866f0ac54d61b9b21a9e746f921cefa4ee94c4c0a1c49c774f67f')
+
+  t.equal(ethUtil.bufferToHex(utils.encodeData('Person', typedData.message.to[0], typedData.types)),
+    '0x' + [
+      'fabfe1ed996349fc6027709802be19d047da1aa5d6894ff5f6486d92db2e6860',
+      '28cac318a86c8a0a6a9156c2dba2c8c2363677ba0514ef616592d81557e679b6',
+      'd2734f4c86cc3bd9cabf04c3097589d3165d95e4648fc72d943ed161f651ec6d',
+    ].join('')
+  )
+  t.equal(ethUtil.bufferToHex(utils.hashStruct('Person', typedData.message.to[0], typedData.types)),
+    '0xefa62530c7ae3a290f8a13a5fc20450bdb3a6af19d9d9d2542b5a94e631a9168')
+
+  t.equal(utils.encodeType('Mail', typedData.types),
+    'Mail(Person from,Person[] to,string contents)Person(string name,address[] wallets)')
+  t.equal(ethUtil.bufferToHex(utils.hashType('Mail', typedData.types)),
+    '0x4bd8a9a2b93427bb184aca81e24beb30ffa3c747e2a33d4225ec08bf12e2e753')
+  t.equal(ethUtil.bufferToHex(utils.encodeData(typedData.primaryType, typedData.message, typedData.types)),
+    '0x' + [
+      '4bd8a9a2b93427bb184aca81e24beb30ffa3c747e2a33d4225ec08bf12e2e753',
+      '9b4846dd48b866f0ac54d61b9b21a9e746f921cefa4ee94c4c0a1c49c774f67f',
+      'ca322beec85be24e374d18d582a6f2997f75c54e7993ab5bc07404ce176ca7cd',
+      'b5aadf3154a261abdd9086fc627b61efca26ae5702701d05cd2305f7c52a2fc8',
+    ].join('')
+  )
+  t.equal(ethUtil.bufferToHex(utils.hashStruct(typedData.primaryType, typedData.message, typedData.types)),
+    '0xeb4221181ff3f1a83ea7313993ca9218496e424604ba9492bb4052c03d5c3df8')
+  t.equal(ethUtil.bufferToHex(utils.hashStruct('EIP712Domain', typedData.domain, typedData.types)),
+    '0xf2cee375fa42b42143804025fc449deafd50cc031ca257e0b194a650a912090f')
+  t.equal(ethUtil.bufferToHex(utils.sign(typedData)),
+    '0xa85c2e2b118698e88db68a8105b794a8cc7cec074e89ef991cb4f5f533819cc2')
+
+  const privateKey = ethUtil.sha3('cow')
+
+  const address = ethUtil.privateToAddress(privateKey)
+  t.equal(ethUtil.bufferToHex(address), '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826')
+
+  const sig = sigUtil.signTypedData_v4(privateKey, { data: typedData })
+
+  t.equal(sig, '0x65cbd956f2fae28a601bebc9b906cea0191744bd4c4247bcd27cd08f8eb6b71c78efdf7a31dc9abee78f492292721f362d296cf86b4538e07b51303b67f749061b')
+})
+
+
 test('signedTypeData_v4', (t) => {
   t.plan(15)
 
@@ -673,6 +871,102 @@ test('signedTypeData_v4 with recursive types', (t) => {
   t.equal(ethUtil.bufferToHex(address), '0x065a687103c9f6467380bee800ecd70b17f6b72f')
 
   const sig = sigUtil.signTypedData_v4(privateKey, { data: typedData })
+
+  t.equal(sig, '0xf2ec61e636ff7bb3ac8bc2a4cc2c8b8f635dd1b2ec8094c963128b358e79c85c5ca6dd637ed7e80f0436fe8fce39c0e5f2082c9517fe677cc2917dcd6c84ba881c')
+})
+
+test('signedTypeMessage V4 with recursive types', (t) => {
+  t.plan(12)
+
+  const typedData = {
+    types: {
+        EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' },
+        ],
+        Person: [
+            { name: 'name', type: 'string' },
+            { name: 'mother', type: 'Person' },
+            { name: 'father', type: 'Person' },
+        ]
+    },
+    domain: {
+        name: 'Family Tree',
+        version: '1',
+        chainId: 1,
+        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+    },
+    primaryType: 'Person',
+    message: {
+        name: 'Jon',
+        mother: {
+          name: 'Lyanna',
+          father: {
+            name: 'Rickard',
+          },
+        },
+        father: {
+          name: 'Rhaegar',
+          father: {
+            name: 'Aeris II',
+          }
+        },
+    },
+  }
+
+  const utils = sigUtil.TypedDataUtils
+
+  t.equal(utils.encodeType('Person', typedData.types),
+    'Person(string name,Person mother,Person father)')
+
+  t.equal(ethUtil.bufferToHex(utils.hashType('Person', typedData.types)),
+    '0x7c5c8e90cb92c8da53b893b24962513be98afcf1b57b00327ae4cc14e3a64116')
+
+  t.equal(ethUtil.bufferToHex(utils.encodeData('Person', typedData.message.mother, typedData.types)),
+    '0x' + [
+      '7c5c8e90cb92c8da53b893b24962513be98afcf1b57b00327ae4cc14e3a64116',
+      'afe4142a2b3e7b0503b44951e6030e0e2c5000ef83c61857e2e6003e7aef8570',
+      '0000000000000000000000000000000000000000000000000000000000000000',
+      '88f14be0dd46a8ec608ccbff6d3923a8b4e95cdfc9648f0db6d92a99a264cb36',
+    ].join('')
+  )
+  t.equal(ethUtil.bufferToHex(utils.hashStruct('Person', typedData.message.mother, typedData.types)),
+    '0x9ebcfbf94f349de50bcb1e3aa4f1eb38824457c99914fefda27dcf9f99f6178b')
+
+  t.equal(ethUtil.bufferToHex(utils.encodeData('Person', typedData.message.father, typedData.types)),
+    '0x' + [
+      '7c5c8e90cb92c8da53b893b24962513be98afcf1b57b00327ae4cc14e3a64116',
+      'b2a7c7faba769181e578a391a6a6811a3e84080c6a3770a0bf8a856dfa79d333',
+      '0000000000000000000000000000000000000000000000000000000000000000',
+      '02cc7460f2c9ff107904cff671ec6fee57ba3dd7decf999fe9fe056f3fd4d56e',
+    ].join('')
+  )
+  t.equal(ethUtil.bufferToHex(utils.hashStruct('Person', typedData.message.father, typedData.types)),
+    '0xb852e5abfeff916a30cb940c4e24c43cfb5aeb0fa8318bdb10dd2ed15c8c70d8')
+
+  t.equal(ethUtil.bufferToHex(utils.encodeData(typedData.primaryType, typedData.message, typedData.types)),
+    '0x' + [
+      '7c5c8e90cb92c8da53b893b24962513be98afcf1b57b00327ae4cc14e3a64116',
+      'e8d55aa98b6b411f04dbcf9b23f29247bb0e335a6bc5368220032fdcb9e5927f',
+      '9ebcfbf94f349de50bcb1e3aa4f1eb38824457c99914fefda27dcf9f99f6178b',
+      'b852e5abfeff916a30cb940c4e24c43cfb5aeb0fa8318bdb10dd2ed15c8c70d8',
+    ].join('')
+  )
+  t.equal(ethUtil.bufferToHex(utils.hashStruct(typedData.primaryType, typedData.message, typedData.types)),
+    '0xfdc7b6d35bbd81f7fa78708604f57569a10edff2ca329c8011373f0667821a45')
+  t.equal(ethUtil.bufferToHex(utils.hashStruct('EIP712Domain', typedData.domain, typedData.types)),
+    '0xfacb2c1888f63a780c84c216bd9a81b516fc501a19bae1fc81d82df590bbdc60')
+  t.equal(ethUtil.bufferToHex(utils.sign(typedData)),
+    '0x807773b9faa9879d4971b43856c4d60c2da15c6f8c062bd9d33afefb756de19c')
+
+  const privateKey = ethUtil.sha3('dragon')
+
+  const address = ethUtil.privateToAddress(privateKey)
+  t.equal(ethUtil.bufferToHex(address), '0x065a687103c9f6467380bee800ecd70b17f6b72f')
+
+  const sig = sigUtil.signTypedMessage(privateKey, { data: typedData }, 'V4')
 
   t.equal(sig, '0xf2ec61e636ff7bb3ac8bc2a4cc2c8b8f635dd1b2ec8094c963128b358e79c85c5ca6dd637ed7e80f0436fe8fce39c0e5f2082c9517fe677cc2917dcd6c84ba881c')
 })


### PR DESCRIPTION
Makes it easier to export the signTyped methods in a generic interface than having to expose each method from each keyring and keyring controller etc going forward.