### PR TITLE
Update CircleCI image to use Node 10 & npm ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,12 @@ workflows:
 jobs:
   npm-test:
     docker:
-      - image: circleci/node:8.15.1-browsers
+      - image: circleci/node:10
     steps:
       - checkout
       - run:
-          name: Install npm 6 + deps via npm
-          command: |
-           sudo npm install -g npm@6 && npm install --no-save --no-audit
+          name: npm ci
+          command: npm ci
       - run:
           name: npm test
           command: npm test


### PR DESCRIPTION
This PR updates the CircleCi configuration to use Node 10 (as the project uses, #77). I've also updated the job steps to use the installed version of `npm@6` and `npm ci`.