### PR TITLE
Update package files & metadata

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto
+
+# Reviewing the lockfile contents is an important step in verifying that
+# we're using the dependencies we expect to be using
+package-lock.json linguist-generated=false
+yarn.lock linguist-generated=false

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules
 .DS_Store
 package-lock.json
 
+*.tgz
+
 # TypeScript
 /build
 **/*.d.ts

--- a/package.json
+++ b/package.json
@@ -3,9 +3,15 @@
   "version": "2.5.2",
   "description": "A few useful functions for signing ethereum data",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "utils/"
+  ],
   "scripts": {
     "build": "tsc --project .",
-    "test": "npm run build && node test/index.js"
+    "test": "npm run build && node test/index.js",
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Refs #79

This PR updates the package metadata, post TypeScript:

- [x] Add `.editorconfig` file
- [x] Add `.gitattributes` file
- [x] Update npm package structure (via `.files` in the `package.json`, diff below)

### npm package structure

**Before:**

```
$ npm pack
npm notice 
npm notice 📦  eth-sig-util@2.5.2
npm notice === Tarball Contents === 
npm notice 790B   package.json          
npm notice 37B    circle.yml            
npm notice 17.1kB index.js              
npm notice 2.9kB  README.md             
npm notice 398B   .circleci/config.yml  
npm notice 35.5kB test/index.js         
npm notice 5.3kB  utils/eccrypto-lite.js
npm notice === Tarball Details === 
npm notice name:          eth-sig-util                            
npm notice version:       2.5.2                                   
npm notice filename:      eth-sig-util-2.5.2.tgz                  
npm notice package size:  13.4 kB                                 
npm notice unpacked size: 62.1 kB                                 
npm notice shasum:        42b5c3ef87f55db76e73dd3f7c482f0d42eb17d8
npm notice integrity:     sha512-9WPFX01ILINqW[...]dXZedLamAzMZQ==
npm notice total files:   7                                       
npm notice 
```

Which is confirmed on a fresh download from npm:

```
$ la node_modules/eth-sig-util/
total 64 
-rw-r--r-- 1 README.md
-rw-r--r-- 1 circle.yml
-rw-r--r-- 1 index.js
-rw-r--r-- 1 package.json
drwxr-xr-x 3 test
drwxr-xr-x 3 utils
```

**After:**

```
$ npm pack
npm notice 
npm notice 📦  eth-sig-util@2.5.2
npm notice === Tarball Contents === 
npm notice 1.0kB  package.json          
npm notice 7.2kB  index.d.ts            
npm notice 20.4kB index.js              
npm notice 2.8kB  README.md             
npm notice 5.3kB  utils/eccrypto-lite.js
npm notice === Tarball Details === 
npm notice name:          eth-sig-util                            
npm notice version:       2.5.2                                   
npm notice filename:      eth-sig-util-2.5.2.tgz                  
npm notice package size:  8.3 kB                                  
npm notice unpacked size: 36.8 kB                                 
npm notice shasum:        da03834127ce49a1f6426588026267eb477a2084
npm notice integrity:     sha512-xaCswPeX2c5Ln[...]Dps0xev46J6KQ==
npm notice total files:   5                                       
npm notice 
```