### PR TITLE
Make need for V4 version of recoverTypedSignature more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Return address of a signer that did `signTypedData`.
 
 Expects the same data that were used for signing. `sig` is a prefixed signature.
 
+### recoverTypedSignature_V4 ({data, sig})
+
+Return address of a signer that did `signTypedData` as per an extension of the published version of [EIP 712](https://github.com/MetaMask/eth-sig-util/pull/54).
+
+This extension adds support for arrays and recursive data types.
+
+Expects the same data that were used for signing. `sig` is a prefixed signature.
+
 ### typedSignatureHash (typedData)
 
 Return hex-encoded hash of typed data params according to [EIP712](https://github.com/ethereum/EIPs/pull/712) schema.

--- a/index.ts
+++ b/index.ts
@@ -153,7 +153,7 @@ const TypedDataUtils = {
             value = ethUtil.sha3(this.encodeData(field.type, value, types, useV4));
             encodedValues.push(value);
           } else if (field.type.lastIndexOf(']') === field.type.length - 1) {
-            throw new Error('Arrays currently unimplemented in encodeData');
+            throw new Error('Arrays are unimplemented in encodeData; use V4 extension');
           } else {
             encodedTypes.push(field.type);
             encodedValues.push(value);


### PR DESCRIPTION
* Include the method in the README
* Update the error message thrown when an array is encountered
  while using v3 signature to give future devs a breadcrumb to
  follow