### PR TITLE
Use typescript@3.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "eslint-plugin-import": "^2.20.1",
     "smokestack": "^3.6.0",
     "tape": "^4.9.1",
-    "typescript": "3.7.4"
+    "typescript": "^3.8.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3397,10 +3397,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.7.4:
-  version "3.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
-  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
+typescript@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 umd@^3.0.0:
   version "3.0.3"


### PR DESCRIPTION
This PR updates the version of TypeScript used to the latest `3.8.x`.