### PR TITLE
Use typescript@3.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "eslint-plugin-import": "^2.20.1",
     "smokestack": "^3.6.0",
     "tape": "^4.9.1",
-    "typescript": "^3.8.3"
+    "typescript": "^3.9.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3397,10 +3397,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@^3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"
+  integrity sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==
 
 umd@^3.0.0:
   version "3.0.3"


### PR DESCRIPTION
This PR updates the version of TypeScript used to the latest [3.9](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html) version.