### PR TITLE
Remove outdated docs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,6 @@ You can find usage examples [here](https://github.com/danfinlay/js-eth-personal-
 
 [Available on NPM](https://www.npmjs.com/package/eth-sig-util)
 
-## Supported Signing Methods
-
-Currently there is only one supported signing protocol. More will be added as standardized.
-
-- Personal Sign (`personal_sign`) [geth thread](https://github.com/ethereum/go-ethereum/pull/2940)
-
-
 ## Installation
 
 ```


### PR DESCRIPTION
This PR removes the outdated _Supported Signing Methods_ section from the README file.