### PR TITLE
Use bl@4.0.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -343,9 +343,9 @@ bl@^0.9.4:
     readable-stream "~1.0.26"
 
 bl@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.2.tgz#52b71e9088515d0606d9dd9cc7aa48dc1f98e73a"
-  integrity sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
+  integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
   dependencies:
     buffer "^5.5.0"
     inherits "^2.0.4"


### PR DESCRIPTION
This PR updates the `bl` dependency to address CVE-2020-8244.

There are no functional changes in [`v4.0.2...v4.0.3`](https://github.com/rvagg/bl/compare/v4.0.2...v4.0.3) per the patch version bump & changelog.