### PR TITLE
3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-sig-util",
-  "version": "2.5.3",
+  "version": "3.0.0",
   "description": "A few useful functions for signing ethereum data",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
- `3.0.0`
  - We're doing this now because 2.5.3 accidentally included breaking changes.