### PR TITLE
Migrate from deprecated `sha3` method to `keccak`

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ const TypedDataUtils = {
         if (types[type] !== undefined) {
           return ['bytes32', value === null || value === undefined ?
             '0x0000000000000000000000000000000000000000000000000000000000000000' :
-            ethUtil.sha3(this.encodeData(type, value, types, useV4))]
+            ethUtil.keccak(this.encodeData(type, value, types, useV4))]
         }
 
         if (value === undefined) {
@@ -58,7 +58,7 @@ const TypedDataUtils = {
         }
 
         if (type === 'bytes') {
-          return ['bytes32', ethUtil.sha3(value)]
+          return ['bytes32', ethUtil.keccak(value)]
         }
 
         if (type === 'string') {
@@ -66,13 +66,13 @@ const TypedDataUtils = {
           if (typeof value === 'string') {
             value = Buffer.from(value, 'utf8')
           }
-          return ['bytes32', ethUtil.sha3(value)]
+          return ['bytes32', ethUtil.keccak(value)]
         }
 
         if (type.lastIndexOf(']') === type.length - 1) {
           const parsedType = type.slice(0, type.lastIndexOf('['))
           const typeValuePairs = value.map((item) => encodeField(name, parsedType, item))
-          return ['bytes32', ethUtil.sha3(ethAbi.rawEncode(
+          return ['bytes32', ethUtil.keccak(ethAbi.rawEncode(
             typeValuePairs.map(([_type]) => _type),
             typeValuePairs.map(([, _value]) => _value),
           ))]
@@ -92,7 +92,7 @@ const TypedDataUtils = {
         if (value !== undefined) {
           if (field.type === 'bytes') {
             encodedTypes.push('bytes32')
-            value = ethUtil.sha3(value)
+            value = ethUtil.keccak(value)
             encodedValues.push(value)
           } else if (field.type === 'string') {
             encodedTypes.push('bytes32')
@@ -100,11 +100,11 @@ const TypedDataUtils = {
             if (typeof value === 'string') {
               value = Buffer.from(value, 'utf8')
             }
-            value = ethUtil.sha3(value)
+            value = ethUtil.keccak(value)
             encodedValues.push(value)
           } else if (types[field.type] !== undefined) {
             encodedTypes.push('bytes32')
-            value = ethUtil.sha3(this.encodeData(field.type, value, types, useV4))
+            value = ethUtil.keccak(this.encodeData(field.type, value, types, useV4))
             encodedValues.push(value)
           } else if (field.type.lastIndexOf(']') === field.type.length - 1) {
             throw new Error('Arrays currently unimplemented in encodeData')
@@ -172,7 +172,7 @@ const TypedDataUtils = {
    * @returns {string} - Hash of an object
    */
   hashStruct (primaryType, data, types, useV4 = true) {
-    return ethUtil.sha3(this.encodeData(primaryType, data, types, useV4))
+    return ethUtil.keccak(this.encodeData(primaryType, data, types, useV4))
   },
 
   /**
@@ -183,7 +183,7 @@ const TypedDataUtils = {
    * @returns {string} - Hash of an object
    */
   hashType (primaryType, types) {
-    return ethUtil.sha3(this.encodeType(primaryType, types))
+    return ethUtil.keccak(this.encodeType(primaryType, types))
   },
 
   /**
@@ -204,10 +204,10 @@ const TypedDataUtils = {
   },
 
   /**
-   * Signs a typed message as per EIP-712 and returns its sha3 hash
+   * Signs a typed message as per EIP-712 and returns its keccak hash
    *
    * @param {Object} typedData - Types message data to sign
-   * @returns {string} - sha3 hash of the resulting signed message
+   * @returns {string} - keccak hash of the resulting signed message
    */
   sign (typedData, useV4 = true) {
     const sanitizedData = this.sanitizeData(typedData)
@@ -216,7 +216,7 @@ const TypedDataUtils = {
     if (sanitizedData.primaryType !== 'EIP712Domain') {
       parts.push(this.hashStruct(sanitizedData.primaryType, sanitizedData.message, sanitizedData.types, useV4))
     }
-    return ethUtil.sha3(Buffer.concat(parts))
+    return ethUtil.keccak(Buffer.concat(parts))
   },
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -487,7 +487,7 @@ test('signedTypeData', (t) => {
   }
 
   const utils = sigUtil.TypedDataUtils
-  const privateKey = ethUtil.sha3('cow')
+  const privateKey = ethUtil.keccak('cow')
   const address = ethUtil.privateToAddress(privateKey)
   const sig = sigUtil.signTypedData(privateKey, { data: typedData })
 
@@ -549,7 +549,7 @@ test('signedTypeData with V3 string', (t) => {
   }
 
   const utils = sigUtil.TypedDataUtils
-  const privateKey = ethUtil.sha3('cow')
+  const privateKey = ethUtil.keccak('cow')
   const address = ethUtil.privateToAddress(privateKey)
   const sig = sigUtil.signTypedMessage(privateKey, { data: typedData }, 'V3')
 
@@ -667,7 +667,7 @@ test('signedTypeData_v4', (t) => {
   t.equal(ethUtil.bufferToHex(utils.sign(typedData)),
     '0xa85c2e2b118698e88db68a8105b794a8cc7cec074e89ef991cb4f5f533819cc2')
 
-  const privateKey = ethUtil.sha3('cow')
+  const privateKey = ethUtil.keccak('cow')
 
   const address = ethUtil.privateToAddress(privateKey)
   t.equal(ethUtil.bufferToHex(address), '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826')
@@ -776,7 +776,7 @@ test('signedTypeData_v4', (t) => {
   t.equal(ethUtil.bufferToHex(utils.sign(typedData)),
     '0xa85c2e2b118698e88db68a8105b794a8cc7cec074e89ef991cb4f5f533819cc2')
 
-  const privateKey = ethUtil.sha3('cow')
+  const privateKey = ethUtil.keccak('cow')
 
   const address = ethUtil.privateToAddress(privateKey)
   t.equal(ethUtil.bufferToHex(address), '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826')
@@ -869,7 +869,7 @@ test('signedTypeData_v4 with recursive types', (t) => {
   t.equal(ethUtil.bufferToHex(utils.sign(typedData)),
     '0x807773b9faa9879d4971b43856c4d60c2da15c6f8c062bd9d33afefb756de19c')
 
-  const privateKey = ethUtil.sha3('dragon')
+  const privateKey = ethUtil.keccak('dragon')
 
   const address = ethUtil.privateToAddress(privateKey)
   t.equal(ethUtil.bufferToHex(address), '0x065a687103c9f6467380bee800ecd70b17f6b72f')
@@ -962,7 +962,7 @@ test('signedTypeMessage V4 with recursive types', (t) => {
   t.equal(ethUtil.bufferToHex(utils.sign(typedData)),
     '0x807773b9faa9879d4971b43856c4d60c2da15c6f8c062bd9d33afefb756de19c')
 
-  const privateKey = ethUtil.sha3('dragon')
+  const privateKey = ethUtil.keccak('dragon')
 
   const address = ethUtil.privateToAddress(privateKey)
   t.equal(ethUtil.bufferToHex(address), '0x065a687103c9f6467380bee800ecd70b17f6b72f')


### PR DESCRIPTION
This is a backport of #118 for the 2.x branch