### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- Update `ethereumjs-abi` ([#121](https://github.com/MetaMask/eth-sig-util/pull/121))
+- Remove unused dependencies ([#120](https://github.com/MetaMask/eth-sig-util/pull/120))
+- Update minimum `tweetnacl` to latest version ([#124](https://github.com/MetaMask/eth-sig-util/pull/124))
+
+## [2.5.3] - 2020-03-16 [WITHDRAWN]
+### Changed
+- [**BREAKING**] Migrate to TypeScript ([#74](https://github.com/MetaMask/eth-sig-util/pull/74))
+- Fix package metadata ([#81](https://github.com/MetaMask/eth-sig-util/pull/81)
+- Switch from Node.js v8 to Node.js v10 ([#76](https://github.com/MetaMask/eth-sig-util/pull/77) and [#80](https://github.com/MetaMask/eth-sig-util/pull/80))
+
+[Unreleased]:https://github.com/MetaMask/eth-sig-util/compare/v2.5.3...HEAD
+[2.5.3]:https://github.com/MetaMask/eth-sig-util/compare/v2.5.2...v2.5.3


### PR DESCRIPTION
This changelog includes v2.5.3 and unreleased 2.x changes. Going back further would require finding which commits to tag, as tags prior to v2.5.2 are missing.