### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Changed
+- Update `ethereumjs-abi` ([#96](https://github.com/MetaMask/eth-sig-util/pull/96))
+- Remove unused dependencies ([#117](https://github.com/MetaMask/eth-sig-util/pull/117))
+- Update minimum `tweetnacl` to latest version ([#123](https://github.com/MetaMask/eth-sig-util/pull/123))
+
+## [3.0.0] - 2020-11-09
+### Changed
+- [**BREAKING**] Migrate to TypeScript ([#74](https://github.com/MetaMask/eth-sig-util/pull/74))
+- Fix package metadata ([#81](https://github.com/MetaMask/eth-sig-util/pull/81)
+- Switch from Node.js v8 to Node.js v10 ([#76](https://github.com/MetaMask/eth-sig-util/pull/77) and [#80](https://github.com/MetaMask/eth-sig-util/pull/80))
+
+
+## [2.5.4] - 2021-02-04
+### Changed
+- Update `ethereumjs-abi` ([#121](https://github.com/MetaMask/eth-sig-util/pull/121))
+- Remove unused dependencies ([#120](https://github.com/MetaMask/eth-sig-util/pull/120))
+- Update minimum `tweetnacl` to latest version ([#124](https://github.com/MetaMask/eth-sig-util/pull/124))
+
+## [2.5.3] - 2020-03-16 [WITHDRAWN]
+### Changed
+- [**BREAKING**] Migrate to TypeScript ([#74](https://github.com/MetaMask/eth-sig-util/pull/74))
+- Fix package metadata ([#81](https://github.com/MetaMask/eth-sig-util/pull/81)
+- Switch from Node.js v8 to Node.js v10 ([#76](https://github.com/MetaMask/eth-sig-util/pull/77) and [#80](https://github.com/MetaMask/eth-sig-util/pull/80))
+
+[Unreleased]:https://github.com/MetaMask/eth-sig-util/compare/v3.0.0...HEAD
+[3.0.0]:https://github.com/MetaMask/eth-sig-util/compare/v2.5.4...v3.0.0
+[2.5.4]:https://github.com/MetaMask/eth-sig-util/compare/v2.5.3...v2.5.4
+[2.5.3]:https://github.com/MetaMask/eth-sig-util/compare/v2.5.2...v2.5.3


### PR DESCRIPTION
This includes everything in the 2.x branch changelog, along with an entry for v3.0.0 and for any unreleased commits.

The entries for v3.0.0 and v2.5.3 are duplicated because those releases are identical apart from version number. Similarly, the unreleased changes are identical to v2.5.4 because v2.5.4 is a backport of those changes to the 2.x branch.