### PR TITLE
Add `build:clean` script and use before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,14 @@
   "scripts": {
     "setup": "yarn install && yarn allow-scripts",
     "build": "tsc --project .",
+    "build:clean": "rimraf dist && yarn build",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:json": "prettier '**/*.json' --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:json --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:json --write",
     "test": "jest",
     "test:watch": "jest --watch",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build:clean"
   },
   "resolutions": {
     "airtap/engine.io-client/xmlhttprequest-ssl": "^1.6.2"
@@ -60,6 +61,7 @@
     "jest": "^27.0.6",
     "prettier": "^2.3.2",
     "prettier-plugin-packagejson": "^2.2.11",
+    "rimraf": "^3.0.2",
     "ts-jest": "^27.0.3",
     "typescript": "^4.1.3"
   },


### PR DESCRIPTION
A `build:clean` script has been added that will completely remove the `dist` directory before building. This is used in the `prepublishOnly` script to ensure that no extra files are shipped from earlier builds.