### PR TITLE
Remove CircleCI badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Eth-Sig-Util [![CircleCI](https://circleci.com/gh/MetaMask/eth-sig-util.svg?style=svg)](https://circleci.com/gh/MetaMask/eth-sig-util)
+# Eth-Sig-Util
 
 A small collection of ethereum signing functions.
 


### PR DESCRIPTION
The badge was left accidentally when we migrated from CircleCI to GitHub Actions in #148