### PR TITLE
Update minimum `tweetnacl-util` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ethereumjs-abi": "^0.6.8",
     "ethereumjs-util": "^5.2.1",
     "tweetnacl": "^1.0.3",
-    "tweetnacl-util": "^0.15.0"
+    "tweetnacl-util": "^0.15.1"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6248,7 +6248,7 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tweetnacl-util@^0.15.0:
+tweetnacl-util@^0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz#b80fcdb5c97bcc508be18c44a4be50f022eea00b"
   integrity sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==


### PR DESCRIPTION
The v0.15.1 release of `tweetnacl-util` fixed [a stack overflow bug](https://github.com/dchest/tweetnacl-util-js/pull/13) that might affect users of this library.

Fixes #130