### PR TITLE
Fix various mistakes in the README API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,37 +36,39 @@ msgParams should have a `data` key that is hex-encoded data unsigned, and a `sig
 
 Returns a hex-encoded sender address.
 
-### signTypedData (privateKeyBuffer, msgParams)
+### signTypedDataLegacy (privateKeyBuffer, msgParams)
 
 Signs typed data as per [an early draft of EIP 712](https://github.com/ethereum/EIPs/pull/712/commits/21abe254fe0452d8583d5b132b1d7be87c0439ca).
 
 Data should be under `data` key of `msgParams`. The method returns prefixed signature.
 
-### signTypedData_v3 (privateKeyBuffer, msgParams)
+### signTypedData (privateKeyBuffer, msgParams)
 
-Signs typed data as per the published version of [EIP 712](https://github.com/ethereum/EIPs/pull/712).
+Signs typed data as per [EIP 712](https://github.com/ethereum/EIPs/pull/712), except that arrays and recursive data structures are not supported.
 
 Data should be under `data` key of `msgParams`. The method returns prefixed signature.
 
 ### signTypedData_v4 (privateKeyBuffer, msgParams)
 
-Signs typed data as per an extension of the published version of [EIP 712](https://github.com/MetaMask/eth-sig-util/pull/54).
-
-This extension adds support for arrays and recursive data types.
+Signs typed data as per [EIP 712](https://github.com/MetaMask/eth-sig-util/pull/54), including support for arrays and recursive data types.
 
 Data should be under `data` key of `msgParams`. The method returns prefixed signature.
 
-### recoverTypedSignature ({data, sig})
+### recoverTypedSignatureLegacy ({data, sig})
 
-Return address of a signer that did `signTypedData`.
+Recover the address of the account used to sign the provided signature. The signature should be of the same type produced by `signTypedDataLegacy`.
 
 Expects the same data that were used for signing. `sig` is a prefixed signature.
 
-### recoverTypedSignature_V4 ({data, sig})
+### recoverTypedSignature ({data, sig})
 
-Return address of a signer that did `signTypedData` as per an extension of the published version of [EIP 712](https://github.com/MetaMask/eth-sig-util/pull/54).
+Recover the address of the account used to sign the provided signature. The signature should be of the same type produced by `signTypedData`.
 
-This extension adds support for arrays and recursive data types.
+Expects the same data that were used for signing. `sig` is a prefixed signature.
+
+### recoverTypedSignature_v4 ({data, sig})
+
+Recover the address of the account used to sign the provided signature. The signature should be of the same type produced by `signTypedData_v4`.
 
 Expects the same data that were used for signing. `sig` is a prefixed signature.
 


### PR DESCRIPTION
The README included various mistakes in the API documentation.

* The `signTypedDataLegacy` function was listed as `signTypedData`
* The `signTypedData` function was listed as `signTypedData_v3`
* The `recoverTypedSignatureLegacy` function was listed as `recoverTypedSignature`
* The `recoverTypedSignature` function was missing
* The `recoverTypedSignature_v4` function was listed as `recoverTypedSignature_V4`

Lastly, the way that `signTypedData` (i.e. `eth_signTypedData_v3`) and `signTypedData_v4` are characterized has been updated. Previously the V3 function was described as fully compliant with EIP-712, whereas V4 was "an extension" of EIP-712, because of added support for arrays and recursive data structures.

But in fact, V3 complies with no version of EIP-712. There was never a version that included [the `\x19\x01` prefix](https://github.com/ethereum/EIPs/pull/712/commits/b658f07f78047b03aa8f0e5fd83512da5ee1cc14) used by V3 but not support for arrays and recursive data structures. The spec supported arrays and recursive data structures since before that prefix was added. V4 has been the version that complies with the specification.

The documentation has been updated to instead describe V4 as spec-compliant, and V3 as spec-compliant except for the lack of support for arrays and recursive data structures.

Fixes #64