### PR TITLE
Use standard TypeScript config

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "scripts": {
     "setup": "yarn install && yarn allow-scripts",
-    "build": "tsc --project ./tsconfig.prod.json && tsc --project ./tsconfig.test.json",
+    "build": "tsc --project ./tsconfig.json && tsc --project ./tsconfig.test.json",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:json": "prettier '**/*.json' --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:json --check",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,15 @@
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,
+    "inlineSources": true,
+    "lib": ["ES2020"],
     "module": "CommonJS",
-    "moduleResolution": "node",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
     "sourceMap": true,
     "target": "ES2017",
     "typeRoots": ["./node_modules/@types"]
-  }
+  },
+  "include": ["./src/**/*.ts"]
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist"
-  },
-  "include": ["./src/*.ts"]
-}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,7 +2,10 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": false,
+    "inlineSources": false,
+    "rootDir": "",
+    "outDir": "",
     "sourceMap": false
   },
-  "files": ["./test/index.ts"]
+  "include": ["./test/index.ts"]
 }


### PR DESCRIPTION
The TypeScript config has been updated to match the configuration we use in other libraries, mostly. The remaining differences are that `strict` is still not enabled, and there is a separate config used for testing. The test config was preserved for now, but that will be replaced soon when we migrate the tests to Jest. `strict` mode will be enabled in a later PR after we update dependencies, as that will make the necessary changes much easier.

The changes are:
* `inlineSources` has been enabled. This embeds a complete copy of the source code with the source maps, allowing for a much better debugging experience.
* `lib` has been set to `ES2020`, ensuring that we only rely upon JavaScript APIs. Previously it also allowed use of browser APIs.
* `rootDir` is now set explicitly to `src`, which will help ensure we don't accidentally change the structure of the package.
* The old `prod` config was merged with the base config, so it was no longer needed as a separate file.

Closes #142