### PR TITLE
Move package under `@metamask` npm organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
-# Eth-Sig-Util
+# `@metamask/eth-sig-util`
 
-A small collection of ethereum signing functions.
+A small collection of Ethereum signing functions.
 
 You can find usage examples [here](https://github.com/metamask/test-dapp)
 
-[Available on NPM](https://www.npmjs.com/package/eth-sig-util)
+[Available on NPM](https://www.npmjs.com/package/@metamask/eth-sig-util)
 
 ## Installation
 
-```shell
-npm install eth-sig-util --save
-```
+`yarn add @metamask/eth-sig-util`
+
+or
+
+`npm install @metamask/eth-sig-util`
 
 ## Methods
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eth-sig-util",
+  "name": "@metamask/eth-sig-util",
   "version": "3.0.1",
   "description": "A few useful functions for signing ethereum data",
   "keywords": [
@@ -60,6 +60,10 @@
   },
   "engines": {
     "node": ">=12.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "lavamoat": {
     "allowScripts": {


### PR DESCRIPTION
The package name is now `@metamask/eth-sig-util` rather than `eth-sig-util`, and the required publish configuration has been added to `package.json`. The README has also been updated with the new name. This includes a link to the future location of the published package that is currently dead, but will be live after the next release.