### PR TITLE
Add `salt` to the EIP-712 `domain` type

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -2,23 +2,23 @@
 
 exports[`TypedDataUtils.eip712Hash V3 should hash a minimal valid typed message 1`] = `"8d4a3f4082945b7879e2b55f181c31a77c8c0a464b70669458abbaaf99de4c38"`;
 
-exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with a domain separator that uses all fields 1`] = `"122d1c8ef94b76dad44dcb03fa772361e20855c63311a15d5afe02d1b38f6077"`;
+exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with a domain separator that uses all fields 1`] = `"54ffed5209a17ac210ef3823740b3852ee9cd518b84ee39f0a3fa7f2f9b4205b"`;
 
-exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with data 1`] = `"122d1c8ef94b76dad44dcb03fa772361e20855c63311a15d5afe02d1b38f6077"`;
+exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with data 1`] = `"54ffed5209a17ac210ef3823740b3852ee9cd518b84ee39f0a3fa7f2f9b4205b"`;
 
-exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with extra domain seperator fields 1`] = `"056edc00a07b3c2f8272146428402cc56419cea26ecdd743301b78053e5aba92"`;
+exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with extra domain seperator fields 1`] = `"2323c742c20093ee44c2a0abef2b950062a3d70b3453ef4995a072dba9e47d7d"`;
 
-exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with only custom domain seperator fields 1`] = `"8e713ff4064ccd8d5cf047d72d1417ba966ed0a4df27251e36aae310414a59b6"`;
+exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with only custom domain seperator fields 1`] = `"3efa3ef0305f56ba5bba62000500e29fe82c5314bca2f958c64e31b2498560f8"`;
 
 exports[`TypedDataUtils.eip712Hash V4 should hash a minimal valid typed message 1`] = `"8d4a3f4082945b7879e2b55f181c31a77c8c0a464b70669458abbaaf99de4c38"`;
 
-exports[`TypedDataUtils.eip712Hash V4 should hash a typed message with a domain separator that uses all fields. 1`] = `"122d1c8ef94b76dad44dcb03fa772361e20855c63311a15d5afe02d1b38f6077"`;
+exports[`TypedDataUtils.eip712Hash V4 should hash a typed message with a domain separator that uses all fields. 1`] = `"54ffed5209a17ac210ef3823740b3852ee9cd518b84ee39f0a3fa7f2f9b4205b"`;
 
-exports[`TypedDataUtils.eip712Hash V4 should hash a typed message with data 1`] = `"122d1c8ef94b76dad44dcb03fa772361e20855c63311a15d5afe02d1b38f6077"`;
+exports[`TypedDataUtils.eip712Hash V4 should hash a typed message with data 1`] = `"54ffed5209a17ac210ef3823740b3852ee9cd518b84ee39f0a3fa7f2f9b4205b"`;
 
-exports[`TypedDataUtils.eip712Hash V4 should hash a typed message with extra domain seperator fields 1`] = `"056edc00a07b3c2f8272146428402cc56419cea26ecdd743301b78053e5aba92"`;
+exports[`TypedDataUtils.eip712Hash V4 should hash a typed message with extra domain seperator fields 1`] = `"2323c742c20093ee44c2a0abef2b950062a3d70b3453ef4995a072dba9e47d7d"`;
 
-exports[`TypedDataUtils.eip712Hash V4 should hash a typed message with only custom domain seperator fields 1`] = `"8e713ff4064ccd8d5cf047d72d1417ba966ed0a4df27251e36aae310414a59b6"`;
+exports[`TypedDataUtils.eip712Hash V4 should hash a typed message with only custom domain seperator fields 1`] = `"3efa3ef0305f56ba5bba62000500e29fe82c5314bca2f958c64e31b2498560f8"`;
 
 exports[`TypedDataUtils.encodeData V3 example data type "address" should encode "0x0" (type "string") 1`] = `"c92db6bca97089c40b3f6512400e065cf2c27db90a50ce13440d951b13ada2990000000000000000000000000000000000000000000000000000000000000000"`;
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3160,6 +3160,10 @@ describe('TypedDataUtils.eip712Hash', function () {
                 name: 'verifyingContract',
                 type: 'address',
               },
+              {
+                name: 'salt',
+                type: 'bytes32',
+              },
             ],
           },
           primaryType: 'EIP712Domain',
@@ -3168,6 +3172,7 @@ describe('TypedDataUtils.eip712Hash', function () {
             version: '1',
             chainId: 1,
             verifyingContract: '0x0000000000000000000000000000000000000000',
+            salt: Buffer.from(new Int32Array([1, 2, 3])),
           },
           message: {},
         },
@@ -3199,6 +3204,10 @@ describe('TypedDataUtils.eip712Hash', function () {
                 type: 'address',
               },
               {
+                name: 'salt',
+                type: 'bytes32',
+              },
+              {
                 name: 'extraField',
                 type: 'string',
               },
@@ -3210,6 +3219,7 @@ describe('TypedDataUtils.eip712Hash', function () {
             version: '1',
             chainId: 1,
             verifyingContract: '0x0000000000000000000000000000000000000000',
+            salt: Buffer.from(new Int32Array([1, 2, 3])),
             extraField: 'stuff',
           },
           message: {},
@@ -3242,6 +3252,10 @@ describe('TypedDataUtils.eip712Hash', function () {
                 type: 'address',
               },
               {
+                name: 'customSalt',
+                type: 'bytes32',
+              },
+              {
                 name: 'extraField',
                 type: 'string',
               },
@@ -3254,6 +3268,7 @@ describe('TypedDataUtils.eip712Hash', function () {
             customChainId: 1,
             customVerifyingContract:
               '0x0000000000000000000000000000000000000000',
+            customSalt: Buffer.from(new Int32Array([1, 2, 3])),
             extraField: 'stuff',
           },
           message: {},
@@ -3285,6 +3300,10 @@ describe('TypedDataUtils.eip712Hash', function () {
                 name: 'verifyingContract',
                 type: 'address',
               },
+              {
+                name: 'salt',
+                type: 'bytes32',
+              },
             ],
             Message: [{ name: 'data', type: 'string' }],
           },
@@ -3294,6 +3313,7 @@ describe('TypedDataUtils.eip712Hash', function () {
             version: '1',
             chainId: 1,
             verifyingContract: '0x0000000000000000000000000000000000000000',
+            salt: Buffer.from(new Int32Array([1, 2, 3])),
           },
           message: {
             data: 'Hello!',
@@ -3405,6 +3425,10 @@ describe('TypedDataUtils.eip712Hash', function () {
                 name: 'verifyingContract',
                 type: 'address',
               },
+              {
+                name: 'salt',
+                type: 'bytes32',
+              },
             ],
           },
           primaryType: 'EIP712Domain',
@@ -3413,6 +3437,7 @@ describe('TypedDataUtils.eip712Hash', function () {
             version: '1',
             chainId: 1,
             verifyingContract: '0x0000000000000000000000000000000000000000',
+            salt: Buffer.from(new Int32Array([1, 2, 3])),
           },
           message: {},
         },
@@ -3444,6 +3469,10 @@ describe('TypedDataUtils.eip712Hash', function () {
                 type: 'address',
               },
               {
+                name: 'salt',
+                type: 'bytes32',
+              },
+              {
                 name: 'extraField',
                 type: 'string',
               },
@@ -3455,6 +3484,7 @@ describe('TypedDataUtils.eip712Hash', function () {
             version: '1',
             chainId: 1,
             verifyingContract: '0x0000000000000000000000000000000000000000',
+            salt: Buffer.from(new Int32Array([1, 2, 3])),
             extraField: 'stuff',
           },
           message: {},
@@ -3487,6 +3517,10 @@ describe('TypedDataUtils.eip712Hash', function () {
                 type: 'address',
               },
               {
+                name: 'customSalt',
+                type: 'bytes32',
+              },
+              {
                 name: 'extraField',
                 type: 'string',
               },
@@ -3499,6 +3533,7 @@ describe('TypedDataUtils.eip712Hash', function () {
             customChainId: 1,
             customVerifyingContract:
               '0x0000000000000000000000000000000000000000',
+            customSalt: Buffer.from(new Int32Array([1, 2, 3])),
             extraField: 'stuff',
           },
           message: {},
@@ -3530,6 +3565,10 @@ describe('TypedDataUtils.eip712Hash', function () {
                 name: 'verifyingContract',
                 type: 'address',
               },
+              {
+                name: 'salt',
+                type: 'bytes32',
+              },
             ],
             Message: [{ name: 'data', type: 'string' }],
           },
@@ -3539,6 +3578,7 @@ describe('TypedDataUtils.eip712Hash', function () {
             version: '1',
             chainId: 1,
             verifyingContract: '0x0000000000000000000000000000000000000000',
+            salt: Buffer.from(new Int32Array([1, 2, 3])),
           },
           message: {
             data: 'Hello!',

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export interface TypedMessage<T extends MessageTypes> {
     version?: string;
     chainId?: number;
     verifyingContract?: string;
+    salt?: ArrayBuffer;
   };
   message: Record<string, unknown>;
 }


### PR DESCRIPTION
The type for the `domain` property of an EIP-712 typed message has been updated to include `salt`, which is in the [EIP-712 specification](https://eips.ethereum.org/EIPS/eip-712#definition-of-encodedata).

The tests have been updated to include this property.

This is an optional property, so this is a non-breaking change.