### PR TITLE
Add docs and tests for `normalize`

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1712,29 +1712,38 @@ describe('concatSig', function () {
   });
 });
 
-it('normalize address lower cases', function () {
-  const initial = '0xA06599BD35921CfB5B71B4BE3869740385b0B306';
-  const result = sigUtil.normalize(initial);
-  expect(result).toBe(initial.toLowerCase());
-});
+describe('normalize', function () {
+  it('should normalize an address to lower case', function () {
+    const initial = '0xA06599BD35921CfB5B71B4BE3869740385b0B306';
+    const result = sigUtil.normalize(initial);
+    expect(result).toBe(initial.toLowerCase());
+  });
 
-it('normalize address adds hex prefix', function () {
-  const initial = 'A06599BD35921CfB5B71B4BE3869740385b0B306';
-  const result = sigUtil.normalize(initial);
-  expect(result).toBe(`0x${initial.toLowerCase()}`);
-});
+  it('should normalize address without a 0x prefix', function () {
+    const initial = 'A06599BD35921CfB5B71B4BE3869740385b0B306';
+    const result = sigUtil.normalize(initial);
+    expect(result).toBe(`0x${initial.toLowerCase()}`);
+  });
 
-it('normalize an integer converts to byte-pair hex', function () {
-  const initial = 1;
-  const result = sigUtil.normalize(initial);
-  expect(result).toBe('0x01');
-});
+  it('should normalize an integer to a byte-pair hex string', function () {
+    const initial = 1;
+    const result = sigUtil.normalize(initial);
+    expect(result).toBe('0x01');
+  });
 
-it('normalize an unsupported type throws', function () {
-  const initial = {};
-  expect(() => sigUtil.normalize(initial as any)).toThrow(
-    'eth-sig-util.normalize() requires hex string or integer input. received object:',
-  );
+  // TODO: Add validation to disallow negative integers.
+  it('should normalize a negative integer to 0x', function () {
+    const initial = -1;
+    const result = sigUtil.normalize(initial);
+    expect(result).toBe('0x');
+  });
+
+  it('should throw if given an object', function () {
+    const initial = {};
+    expect(() => sigUtil.normalize(initial as any)).toThrow(
+      'eth-sig-util.normalize() requires hex string or integer input. received object:',
+    );
+  });
 });
 
 it('personalSign and recover', function () {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3049,7 +3049,7 @@ describe('normalize', function () {
     expect(result).toBe('0x');
   });
 
-  // TODO: Add validation to disallow undefined.
+  // TODO: Add validation to disallow null.
   it('should return undefined if given null', function () {
     const initial = null;
     expect(sigUtil.normalize(initial as any)).toBeUndefined();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1738,10 +1738,43 @@ describe('normalize', function () {
     expect(result).toBe('0x');
   });
 
+  // TODO: Add validation to disallow undefined.
+  it('should return undefined if given null', function () {
+    const initial = null;
+    expect(sigUtil.normalize(initial as any)).toBeUndefined();
+  });
+
+  // TODO: Add validation to disallow null.
+  it('should return undefined if given undefined', function () {
+    const initial = undefined;
+    expect(sigUtil.normalize(initial as any)).toBeUndefined();
+  });
+
   it('should throw if given an object', function () {
     const initial = {};
     expect(() => sigUtil.normalize(initial as any)).toThrow(
       'eth-sig-util.normalize() requires hex string or integer input. received object:',
+    );
+  });
+
+  it('should throw if given a boolean', function () {
+    const initial = true;
+    expect(() => sigUtil.normalize(initial as any)).toThrow(
+      'eth-sig-util.normalize() requires hex string or integer input. received boolean: true',
+    );
+  });
+
+  it('should throw if given a bigint', function () {
+    const initial = BigInt(Number.MAX_SAFE_INTEGER);
+    expect(() => sigUtil.normalize(initial as any)).toThrow(
+      'eth-sig-util.normalize() requires hex string or integer input. received bigint: 9007199254740991',
+    );
+  });
+
+  it('should throw if given a sumbol', function () {
+    const initial = Symbol('test');
+    expect(() => sigUtil.normalize(initial as any)).toThrow(
+      'Cannot convert a Symbol value to a string',
     );
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3075,7 +3075,7 @@ describe('normalize', function () {
     );
   });
 
-  it('should throw if given a BigInt', function () {
+  it('should throw if given a bigint', function () {
     const initial = BigInt(Number.MAX_SAFE_INTEGER);
     expect(() => sigUtil.normalize(initial as any)).toThrow(
       'eth-sig-util.normalize() requires hex string or integer input. received bigint: 9007199254740991',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3075,7 +3075,7 @@ describe('normalize', function () {
     );
   });
 
-  it('should throw if given a bigint', function () {
+  it('should throw if given a BigInt', function () {
     const initial = BigInt(Number.MAX_SAFE_INTEGER);
     expect(() => sigUtil.normalize(initial as any)).toThrow(
       'eth-sig-util.normalize() requires hex string or integer input. received bigint: 9007199254740991',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3082,7 +3082,7 @@ describe('normalize', function () {
     );
   });
 
-  it('should throw if given a sumbol', function () {
+  it('should throw if given a symbol', function () {
     const initial = Symbol('test');
     expect(() => sigUtil.normalize(initial as any)).toThrow(
       'Cannot convert a Symbol value to a string',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3055,7 +3055,7 @@ describe('normalize', function () {
     expect(sigUtil.normalize(initial as any)).toBeUndefined();
   });
 
-  // TODO: Add validation to disallow null.
+  // TODO: Add validation to disallow undefined.
   it('should return undefined if given undefined', function () {
     const initial = undefined;
     expect(sigUtil.normalize(initial as any)).toBeUndefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -369,7 +369,8 @@ export function concatSig(v: Buffer, r: Buffer, s: Buffer): string {
 /**
  * Normalize the input to a 0x-prefixed hex string.
  *
- * @param input - The value to normalize
+ * @param input - The value to normalize.
+ * @returns The normalized 0x-prefixed hex string.
  */
 export function normalize(input: number | string): string {
   if (!input) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -366,6 +366,11 @@ export function concatSig(v: Buffer, r: Buffer, s: Buffer): string {
   return ethUtil.addHexPrefix(rStr.concat(sStr, vStr)).toString('hex');
 }
 
+/**
+ * Normalize the input to a 0x-prefixed hex string.
+ *
+ * @param input - The value to normalize
+ */
 export function normalize(input: number | string): string {
   if (!input) {
     return undefined;


### PR DESCRIPTION
Inline documentation and tests have been added for the `normalize` function. Only one test was added; the rest were pre-existing. They were grouped together and updated to match our typical testing conventions.