### PR TITLE
Add `.prettierrc.js`

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,8 @@
+// All of these are defaults except singleQuote, but we specify them
+// for explicitness
+module.exports = {
+  quoteProps: 'as-needed',
+  singleQuote: true,
+  tabWidth: 2,
+  trailingComma: 'all',
+};


### PR DESCRIPTION
This file was accidentally omitted when updating the linter. As a result `prettier` and `ESLint` have been clashing over the formatting, which slows down the linter. They are now aligned, and the linter is faster.