### PR TITLE
Fix `eip712Hash` tests that included data

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -4,7 +4,7 @@ exports[`TypedDataUtils.eip712Hash V3 should hash a minimal valid typed message 
 
 exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with a domain separator that uses all fields 1`] = `"54ffed5209a17ac210ef3823740b3852ee9cd518b84ee39f0a3fa7f2f9b4205b"`;
 
-exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with data 1`] = `"54ffed5209a17ac210ef3823740b3852ee9cd518b84ee39f0a3fa7f2f9b4205b"`;
+exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with data 1`] = `"d2669f23b7849020ad41bcbff5b51372793f91320e0f901641945568ed7322be"`;
 
 exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with extra domain seperator fields 1`] = `"2323c742c20093ee44c2a0abef2b950062a3d70b3453ef4995a072dba9e47d7d"`;
 
@@ -14,7 +14,7 @@ exports[`TypedDataUtils.eip712Hash V4 should hash a minimal valid typed message 
 
 exports[`TypedDataUtils.eip712Hash V4 should hash a typed message with a domain separator that uses all fields. 1`] = `"54ffed5209a17ac210ef3823740b3852ee9cd518b84ee39f0a3fa7f2f9b4205b"`;
 
-exports[`TypedDataUtils.eip712Hash V4 should hash a typed message with data 1`] = `"54ffed5209a17ac210ef3823740b3852ee9cd518b84ee39f0a3fa7f2f9b4205b"`;
+exports[`TypedDataUtils.eip712Hash V4 should hash a typed message with data 1`] = `"d2669f23b7849020ad41bcbff5b51372793f91320e0f901641945568ed7322be"`;
 
 exports[`TypedDataUtils.eip712Hash V4 should hash a typed message with extra domain seperator fields 1`] = `"2323c742c20093ee44c2a0abef2b950062a3d70b3453ef4995a072dba9e47d7d"`;
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3307,7 +3307,7 @@ describe('TypedDataUtils.eip712Hash', function () {
             ],
             Message: [{ name: 'data', type: 'string' }],
           },
-          primaryType: 'EIP712Domain',
+          primaryType: 'Message',
           domain: {
             name: 'example.metamask.io',
             version: '1',
@@ -3323,6 +3323,93 @@ describe('TypedDataUtils.eip712Hash', function () {
       );
 
       expect(hash.toString('hex')).toMatchSnapshot();
+    });
+
+    it('should ignore message if the primary type is EIP712Domain', function () {
+      const hashWithMessage = sigUtil.TypedDataUtils.eip712Hash(
+        {
+          types: {
+            EIP712Domain: [
+              {
+                name: 'name',
+                type: 'string',
+              },
+              {
+                name: 'version',
+                type: 'string',
+              },
+              {
+                name: 'chainId',
+                type: 'uint256',
+              },
+              {
+                name: 'verifyingContract',
+                type: 'address',
+              },
+              {
+                name: 'salt',
+                type: 'bytes32',
+              },
+            ],
+            Message: [{ name: 'data', type: 'string' }],
+          },
+          primaryType: 'EIP712Domain',
+          domain: {
+            name: 'example.metamask.io',
+            version: '1',
+            chainId: 1,
+            verifyingContract: '0x0000000000000000000000000000000000000000',
+            salt: Buffer.from(new Int32Array([1, 2, 3])),
+          },
+          message: {
+            data: 'Hello!',
+          },
+        },
+        'V3',
+      );
+      const hashWithoutMessage = sigUtil.TypedDataUtils.eip712Hash(
+        {
+          types: {
+            EIP712Domain: [
+              {
+                name: 'name',
+                type: 'string',
+              },
+              {
+                name: 'version',
+                type: 'string',
+              },
+              {
+                name: 'chainId',
+                type: 'uint256',
+              },
+              {
+                name: 'verifyingContract',
+                type: 'address',
+              },
+              {
+                name: 'salt',
+                type: 'bytes32',
+              },
+            ],
+            Message: [{ name: 'data', type: 'string' }],
+          },
+          primaryType: 'EIP712Domain',
+          domain: {
+            name: 'example.metamask.io',
+            version: '1',
+            chainId: 1,
+            verifyingContract: '0x0000000000000000000000000000000000000000',
+            salt: Buffer.from(new Int32Array([1, 2, 3])),
+          },
+          message: {},
+        },
+        'V3',
+      );
+
+      expect(hashWithMessage.toString('hex')).toBe(
+        hashWithoutMessage.toString('hex'),
+      );
     });
   });
 
@@ -3572,7 +3659,7 @@ describe('TypedDataUtils.eip712Hash', function () {
             ],
             Message: [{ name: 'data', type: 'string' }],
           },
-          primaryType: 'EIP712Domain',
+          primaryType: 'Message',
           domain: {
             name: 'example.metamask.io',
             version: '1',
@@ -3588,6 +3675,93 @@ describe('TypedDataUtils.eip712Hash', function () {
       );
 
       expect(hash.toString('hex')).toMatchSnapshot();
+    });
+
+    it('should ignore message if the primary type is EIP712Domain', function () {
+      const hashWithMessage = sigUtil.TypedDataUtils.eip712Hash(
+        {
+          types: {
+            EIP712Domain: [
+              {
+                name: 'name',
+                type: 'string',
+              },
+              {
+                name: 'version',
+                type: 'string',
+              },
+              {
+                name: 'chainId',
+                type: 'uint256',
+              },
+              {
+                name: 'verifyingContract',
+                type: 'address',
+              },
+              {
+                name: 'salt',
+                type: 'bytes32',
+              },
+            ],
+            Message: [{ name: 'data', type: 'string' }],
+          },
+          primaryType: 'EIP712Domain',
+          domain: {
+            name: 'example.metamask.io',
+            version: '1',
+            chainId: 1,
+            verifyingContract: '0x0000000000000000000000000000000000000000',
+            salt: Buffer.from(new Int32Array([1, 2, 3])),
+          },
+          message: {
+            data: 'Hello!',
+          },
+        },
+        'V4',
+      );
+      const hashWithoutMessage = sigUtil.TypedDataUtils.eip712Hash(
+        {
+          types: {
+            EIP712Domain: [
+              {
+                name: 'name',
+                type: 'string',
+              },
+              {
+                name: 'version',
+                type: 'string',
+              },
+              {
+                name: 'chainId',
+                type: 'uint256',
+              },
+              {
+                name: 'verifyingContract',
+                type: 'address',
+              },
+              {
+                name: 'salt',
+                type: 'bytes32',
+              },
+            ],
+            Message: [{ name: 'data', type: 'string' }],
+          },
+          primaryType: 'EIP712Domain',
+          domain: {
+            name: 'example.metamask.io',
+            version: '1',
+            chainId: 1,
+            verifyingContract: '0x0000000000000000000000000000000000000000',
+            salt: Buffer.from(new Int32Array([1, 2, 3])),
+          },
+          message: {},
+        },
+        'V4',
+      );
+
+      expect(hashWithMessage.toString('hex')).toBe(
+        hashWithoutMessage.toString('hex'),
+      );
     });
   });
 });


### PR DESCRIPTION
The `eip712Hash` tests that included data had the wrong `primaryType`, so the data wasn't actually included in the resulting hash. This was an edge case that had not been considered, so another test was added to capture it.