### PR TITLE
Fix `typedSignatureHash` documentation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -452,10 +452,10 @@ export function extractPublicKey<T extends MessageTypes>(
 }
 
 /**
- * Generate the "V1" type hash for the provided typed message.
+ * Generate the "V1" hash for the provided typed message.
  *
- * The type hash will be generated in accordance with an earlier version of the EIP-712
- * specification. This type hash is used in `signTypedData_v1`.
+ * The hash will be generated in accordance with an earlier version of the EIP-712
+ * specification. This hash is used in `signTypedData_v1`.
  *
  * @param typedData - The typed message.
  * @returns The type hash for the provided message.


### PR DESCRIPTION
The inline docs erroneously described this function as returning a type hash for "V1" of `signTypedData`. But "V1" didn't include a type hash. Rather, this function returns the hash of the entire message.