### PR TITLE
Reorganize `TypedDataUtils` unbound tests

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`TypedDataUtils.eip712Hash V3 should hash a minimal valid typed message 1`] = `"8d4a3f4082945b7879e2b55f181c31a77c8c0a464b70669458abbaaf99de4c38"`;
 
+exports[`TypedDataUtils.eip712Hash V3 should hash a minimal valid typed message when called unbound 1`] = `"8d4a3f4082945b7879e2b55f181c31a77c8c0a464b70669458abbaaf99de4c38"`;
+
 exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with a domain separator that uses all fields 1`] = `"54ffed5209a17ac210ef3823740b3852ee9cd518b84ee39f0a3fa7f2f9b4205b"`;
 
 exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with data 1`] = `"d2669f23b7849020ad41bcbff5b51372793f91320e0f901641945568ed7322be"`;
@@ -11,6 +13,8 @@ exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with extra dom
 exports[`TypedDataUtils.eip712Hash V3 should hash a typed message with only custom domain seperator fields 1`] = `"3efa3ef0305f56ba5bba62000500e29fe82c5314bca2f958c64e31b2498560f8"`;
 
 exports[`TypedDataUtils.eip712Hash V4 should hash a minimal valid typed message 1`] = `"8d4a3f4082945b7879e2b55f181c31a77c8c0a464b70669458abbaaf99de4c38"`;
+
+exports[`TypedDataUtils.eip712Hash V4 should hash a minimal valid typed message when called unbound 1`] = `"8d4a3f4082945b7879e2b55f181c31a77c8c0a464b70669458abbaaf99de4c38"`;
 
 exports[`TypedDataUtils.eip712Hash V4 should hash a typed message with a domain separator that uses all fields. 1`] = `"54ffed5209a17ac210ef3823740b3852ee9cd518b84ee39f0a3fa7f2f9b4205b"`;
 
@@ -145,6 +149,8 @@ exports[`TypedDataUtils.encodeData V3 example data type "uint256" should encode 
 exports[`TypedDataUtils.encodeData V3 example data type "uint256" should encode "0x0" (type "string") 1`] = `"313eafedfe20c8366f87086b9ac5b8b0ad47b49842a8eb76a8a746dfea3ff8d10000000000000000000000000000000000000000000000000000000000000000"`;
 
 exports[`TypedDataUtils.encodeData V3 example data type "uint256" should encode "9007199254740991" (type "number") 1`] = `"313eafedfe20c8366f87086b9ac5b8b0ad47b49842a8eb76a8a746dfea3ff8d1000000000000000000000000000000000000000000000000001fffffffffffff"`;
+
+exports[`TypedDataUtils.encodeData V3 should encode data when called unbound 1`] = `"15d2c54cdaa22a6a3a8dbd89086b2ffcf0853857db9bcf1541765a8f769a63ba"`;
 
 exports[`TypedDataUtils.encodeData V3 should encode data when given extraneous types 1`] = `"cddf41b07426e1a761f3da57e35474ae3deaa5b596306531f651c6dc1321e4fd6cdba77591a790691c694fa0be937f835b8a589095e427022aa1035e579ee596"`;
 
@@ -310,6 +316,8 @@ exports[`TypedDataUtils.encodeData V4 example data type "uint256" should encode 
 
 exports[`TypedDataUtils.encodeData V4 example data type "uint256" should encode array of all uint256 example data 1`] = `"cdf19ca88de01fa689a36bc72e26bca5dcb8b87b50500b28ff442503c5dff8eb466f8762ff33f5d78b80f620538cd343b1823cc87cd806412f5d280cfad3b799"`;
 
+exports[`TypedDataUtils.encodeData V4 should encode data when called unbound 1`] = `"cddf41b07426e1a761f3da57e35474ae3deaa5b596306531f651c6dc1321e4fd6cdba77591a790691c694fa0be937f835b8a589095e427022aa1035e579ee596"`;
+
 exports[`TypedDataUtils.encodeData V4 should encode data when given extraneous types 1`] = `"cddf41b07426e1a761f3da57e35474ae3deaa5b596306531f651c6dc1321e4fd6cdba77591a790691c694fa0be937f835b8a589095e427022aa1035e579ee596"`;
 
 exports[`TypedDataUtils.encodeData V4 should encode data with a custom data type array 1`] = `"077b2e5169bfc57ed1b6acf858d27ae9b8311db1ccf71df99dfcf9efe8eec43856cacfdc07c6f697bc1bc978cf38559d5c729ed1cd1177e047df929e19dc2a2e8548546251a0cc6d0005e1a792e00f85feed5056e580102ed1afa615f87bb130b5aadf3154a261abdd9086fc627b61efca26ae5702701d05cd2305f7c52a2fc8"`;
@@ -449,6 +457,8 @@ exports[`TypedDataUtils.hashStruct V3 example data type "uint256" should hash "0
 exports[`TypedDataUtils.hashStruct V3 example data type "uint256" should hash "0x0" (type "string") 1`] = `"c4adc42f66c4586eb979042b897a75bc2bd4c8fb866531c44100a22168cdcdbc"`;
 
 exports[`TypedDataUtils.hashStruct V3 example data type "uint256" should hash "9007199254740991" (type "number") 1`] = `"3cfc99947ae18942816da1e3a94b479043b95f4de5851660ce9d53fe5f29b686"`;
+
+exports[`TypedDataUtils.hashStruct V3 should hash data when called unbound 1`] = `"15d2c54cdaa22a6a3a8dbd89086b2ffcf0853857db9bcf1541765a8f769a63ba"`;
 
 exports[`TypedDataUtils.hashStruct V3 should hash data when given extraneous types 1`] = `"15d2c54cdaa22a6a3a8dbd89086b2ffcf0853857db9bcf1541765a8f769a63ba"`;
 
@@ -613,6 +623,8 @@ exports[`TypedDataUtils.hashStruct V4 example data type "uint256" should hash "0
 exports[`TypedDataUtils.hashStruct V4 example data type "uint256" should hash "9007199254740991" (type "number") 1`] = `"3cfc99947ae18942816da1e3a94b479043b95f4de5851660ce9d53fe5f29b686"`;
 
 exports[`TypedDataUtils.hashStruct V4 example data type "uint256" should hash array of all uint256 example data 1`] = `"f44a78e7f58e62916b00244626970fb046c4e6495bd453c83298686c00d8e9f0"`;
+
+exports[`TypedDataUtils.hashStruct V4 should hash data when called unbound 1`] = `"15d2c54cdaa22a6a3a8dbd89086b2ffcf0853857db9bcf1541765a8f769a63ba"`;
 
 exports[`TypedDataUtils.hashStruct V4 should hash data when given extraneous types 1`] = `"15d2c54cdaa22a6a3a8dbd89086b2ffcf0853857db9bcf1541765a8f769a63ba"`;
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -611,6 +611,19 @@ describe('TypedDataUtils.encodeData', function () {
         ).toString('hex'),
       ).toMatchSnapshot();
     });
+
+    it('should encode data when called unbound', function () {
+      const types = {
+        Message: [{ name: 'data', type: 'string' }],
+      };
+      const message = { data: 'Hello!' };
+      const primaryType = 'Message';
+      const { hashStruct } = sigUtil.TypedDataUtils;
+
+      expect(
+        hashStruct(primaryType, message, types, 'V3').toString('hex'),
+      ).toMatchSnapshot();
+    });
   });
 
   describe('V4', function () {
@@ -1118,6 +1131,19 @@ describe('TypedDataUtils.encodeData', function () {
           types,
           'V4',
         ).toString('hex'),
+      ).toMatchSnapshot();
+    });
+
+    it('should encode data when called unbound', function () {
+      const types = {
+        Message: [{ name: 'data', type: 'string' }],
+      };
+      const message = { data: 'Hello!' };
+      const primaryType = 'Message';
+      const { encodeData } = sigUtil.TypedDataUtils;
+
+      expect(
+        encodeData(primaryType, message, types, 'V4').toString('hex'),
       ).toMatchSnapshot();
     });
   });
@@ -1919,6 +1945,19 @@ describe('TypedDataUtils.hashStruct', function () {
         ).toString('hex'),
       ).toMatchSnapshot();
     });
+
+    it('should hash data when called unbound', function () {
+      const types = {
+        Message: [{ name: 'data', type: 'string' }],
+      };
+      const message = { data: 'Hello!' };
+      const primaryType = 'Message';
+      const { hashStruct } = sigUtil.TypedDataUtils;
+
+      expect(
+        hashStruct(primaryType, message, types, 'V3').toString('hex'),
+      ).toMatchSnapshot();
+    });
   });
 
   describe('V4', function () {
@@ -2428,6 +2467,19 @@ describe('TypedDataUtils.hashStruct', function () {
         ).toString('hex'),
       ).toMatchSnapshot();
     });
+
+    it('should hash data when called unbound', function () {
+      const types = {
+        Message: [{ name: 'data', type: 'string' }],
+      };
+      const message = { data: 'Hello!' };
+      const primaryType = 'Message';
+      const { hashStruct } = sigUtil.TypedDataUtils;
+
+      expect(
+        hashStruct(primaryType, message, types, 'V4').toString('hex'),
+      ).toMatchSnapshot();
+    });
   });
 
   // This test suite covers all cases where data should be encoded identically
@@ -2821,6 +2873,18 @@ describe('TypedDataUtils.encodeType', () => {
       'No type definition specified: Mail',
     );
   });
+
+  it('should encode type when called unbound', function () {
+    const types = {
+      Message: [{ name: 'data', type: 'string' }],
+    };
+    const primaryType = 'Message';
+    const { encodeType } = sigUtil.TypedDataUtils;
+
+    expect(encodeType(primaryType, types)).toMatchInlineSnapshot(
+      `"Message(string data)"`,
+    );
+  });
 });
 
 describe('TypedDataUtils.hashType', () => {
@@ -2911,6 +2975,18 @@ describe('TypedDataUtils.hashType', () => {
       sigUtil.TypedDataUtils.hashType(primaryType, types).toString('hex'),
     ).toThrow('No type definition specified: Mail');
   });
+
+  it('should hash type when called unbound', function () {
+    const types = {
+      Message: [{ name: 'data', type: 'string' }],
+    };
+    const primaryType = 'Message';
+    const { hashType } = sigUtil.TypedDataUtils;
+
+    expect(hashType(primaryType, types).toString('hex')).toMatchInlineSnapshot(
+      `"cddf41b07426e1a761f3da57e35474ae3deaa5b596306531f651c6dc1321e4fd"`,
+    );
+  });
 });
 
 describe('TypedDataUtils.findTypeDependencies', () => {
@@ -2981,6 +3057,18 @@ describe('TypedDataUtils.findTypeDependencies', () => {
     expect(
       sigUtil.TypedDataUtils.findTypeDependencies(primaryType, {}),
     ).toStrictEqual(new Set());
+  });
+
+  it('should return type dependencies when called unbound', function () {
+    const types = {
+      Person: [{ name: 'name', type: 'string' }],
+    };
+    const primaryType = 'Person';
+    const { findTypeDependencies } = sigUtil.TypedDataUtils;
+
+    expect(findTypeDependencies(primaryType, types)).toStrictEqual(
+      new Set(['Person']),
+    );
   });
 });
 
@@ -3057,6 +3145,26 @@ describe('TypedDataUtils.sanitizeData', function () {
       sigUtil.TypedDataUtils.sanitizeData(typedMessage);
 
     expect(sanitizedTypedMessage).toStrictEqual(expectedMessage);
+  });
+
+  it('should sanitize data when called unbound', function () {
+    const typedMessage = {
+      domain: {},
+      message: {},
+      primaryType: 'Person' as const,
+      types: {
+        EIP712Domain: [{ name: 'name', type: 'string' }],
+        Person: [
+          { name: 'name', type: 'string' },
+          { name: 'wallet', type: 'address' },
+        ],
+      },
+    };
+    const { sanitizeData } = sigUtil.TypedDataUtils;
+
+    const sanitizedTypedMessage = sanitizeData(typedMessage);
+
+    expect(sanitizedTypedMessage).toStrictEqual(typedMessage);
   });
 });
 
@@ -3411,6 +3519,27 @@ describe('TypedDataUtils.eip712Hash', function () {
         hashWithoutMessage.toString('hex'),
       );
     });
+
+    it('should hash a minimal valid typed message when called unbound', function () {
+      const { eip712Hash } = sigUtil.TypedDataUtils;
+
+      const hash = eip712Hash(
+        // This represents the most basic "typed message" that is valid according to our types.
+        // It's not a very useful message (it's totally empty), but it's complete according to the
+        // spec.
+        {
+          types: {
+            EIP712Domain: [],
+          },
+          primaryType: 'EIP712Domain',
+          domain: {},
+          message: {},
+        },
+        'V3',
+      );
+
+      expect(hash.toString('hex')).toMatchSnapshot();
+    });
   });
 
   describe('V4', function () {
@@ -3762,6 +3891,27 @@ describe('TypedDataUtils.eip712Hash', function () {
       expect(hashWithMessage.toString('hex')).toBe(
         hashWithoutMessage.toString('hex'),
       );
+    });
+
+    it('should hash a minimal valid typed message when called unbound', function () {
+      const { eip712Hash } = sigUtil.TypedDataUtils;
+
+      // This represents the most basic "typed message" that is valid according to our types.
+      // It's not a very useful message (it's totally empty), but it's complete according to the
+      // spec.
+      const hash = eip712Hash(
+        {
+          types: {
+            EIP712Domain: [],
+          },
+          primaryType: 'EIP712Domain',
+          domain: {},
+          message: {},
+        },
+        'V4',
+      );
+
+      expect(hash.toString('hex')).toMatchSnapshot();
     });
   });
 });
@@ -4667,128 +4817,5 @@ it('signedTypeMessage V4 with recursive types', function () {
 
   expect(sig).toBe(
     '0xf2ec61e636ff7bb3ac8bc2a4cc2c8b8f635dd1b2ec8094c963128b358e79c85c5ca6dd637ed7e80f0436fe8fce39c0e5f2082c9517fe677cc2917dcd6c84ba881c',
-  );
-});
-
-it('unbound sign typed data utility functions', function () {
-  const typedData = {
-    types: {
-      EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-      ],
-      Person: [
-        { name: 'name', type: 'string' },
-        { name: 'mother', type: 'Person' },
-        { name: 'father', type: 'Person' },
-      ],
-    },
-    domain: {
-      name: 'Family Tree',
-      version: '1',
-      chainId: 1,
-      verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
-    },
-    primaryType: 'Person' as const,
-    message: {
-      name: 'Jon',
-      mother: {
-        name: 'Lyanna',
-        father: {
-          name: 'Rickard',
-        },
-      },
-      father: {
-        name: 'Rhaegar',
-        father: {
-          name: 'Aeris II',
-        },
-      },
-    },
-  };
-
-  const { encodeData, encodeType, hashStruct, hashType, eip712Hash } =
-    sigUtil.TypedDataUtils;
-
-  expect(encodeType('Person', typedData.types)).toBe(
-    'Person(string name,Person mother,Person father)',
-  );
-
-  expect(ethUtil.bufferToHex(hashType('Person', typedData.types))).toBe(
-    '0x7c5c8e90cb92c8da53b893b24962513be98afcf1b57b00327ae4cc14e3a64116',
-  );
-
-  expect(
-    ethUtil.bufferToHex(
-      encodeData('Person', typedData.message.mother, typedData.types, 'V4'),
-    ),
-  ).toBe(
-    `0x${[
-      '7c5c8e90cb92c8da53b893b24962513be98afcf1b57b00327ae4cc14e3a64116',
-      'afe4142a2b3e7b0503b44951e6030e0e2c5000ef83c61857e2e6003e7aef8570',
-      '0000000000000000000000000000000000000000000000000000000000000000',
-      '88f14be0dd46a8ec608ccbff6d3923a8b4e95cdfc9648f0db6d92a99a264cb36',
-    ].join('')}`,
-  );
-  expect(
-    ethUtil.bufferToHex(
-      hashStruct('Person', typedData.message.mother, typedData.types, 'V4'),
-    ),
-  ).toBe('0x9ebcfbf94f349de50bcb1e3aa4f1eb38824457c99914fefda27dcf9f99f6178b');
-
-  expect(
-    ethUtil.bufferToHex(
-      encodeData('Person', typedData.message.father, typedData.types, 'V4'),
-    ),
-  ).toBe(
-    `0x${[
-      '7c5c8e90cb92c8da53b893b24962513be98afcf1b57b00327ae4cc14e3a64116',
-      'b2a7c7faba769181e578a391a6a6811a3e84080c6a3770a0bf8a856dfa79d333',
-      '0000000000000000000000000000000000000000000000000000000000000000',
-      '02cc7460f2c9ff107904cff671ec6fee57ba3dd7decf999fe9fe056f3fd4d56e',
-    ].join('')}`,
-  );
-  expect(
-    ethUtil.bufferToHex(
-      hashStruct('Person', typedData.message.father, typedData.types, 'V4'),
-    ),
-  ).toBe('0xb852e5abfeff916a30cb940c4e24c43cfb5aeb0fa8318bdb10dd2ed15c8c70d8');
-
-  expect(
-    ethUtil.bufferToHex(
-      encodeData(
-        typedData.primaryType,
-        typedData.message,
-        typedData.types,
-        'V4',
-      ),
-    ),
-  ).toBe(
-    `0x${[
-      '7c5c8e90cb92c8da53b893b24962513be98afcf1b57b00327ae4cc14e3a64116',
-      'e8d55aa98b6b411f04dbcf9b23f29247bb0e335a6bc5368220032fdcb9e5927f',
-      '9ebcfbf94f349de50bcb1e3aa4f1eb38824457c99914fefda27dcf9f99f6178b',
-      'b852e5abfeff916a30cb940c4e24c43cfb5aeb0fa8318bdb10dd2ed15c8c70d8',
-    ].join('')}`,
-  );
-  expect(
-    ethUtil.bufferToHex(
-      hashStruct(
-        typedData.primaryType,
-        typedData.message,
-        typedData.types,
-        'V4',
-      ),
-    ),
-  ).toBe('0xfdc7b6d35bbd81f7fa78708604f57569a10edff2ca329c8011373f0667821a45');
-  expect(
-    ethUtil.bufferToHex(
-      hashStruct('EIP712Domain', typedData.domain, typedData.types, 'V4'),
-    ),
-  ).toBe('0xfacb2c1888f63a780c84c216bd9a81b516fc501a19bae1fc81d82df590bbdc60');
-  expect(ethUtil.bufferToHex(eip712Hash(typedData, 'V4'))).toBe(
-    '0x807773b9faa9879d4971b43856c4d60c2da15c6f8c062bd9d33afefb756de19c',
   );
 });


### PR DESCRIPTION
The tests that ensure the `TypedDataUtils` functions still work when called unbound have been reorganized. Rather than being all in one `it` block at the end of the file, they're now tested as part of the test suite for each individual function. This matches our usual testing conventions.