### PR TITLE
Add solidity types to schema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export const TYPED_MESSAGE_SCHEMA = {
           type: 'object',
           properties: {
             name: { type: 'string' },
-            type: { type: 'string' },
+            type: { type: 'string', enum: getSolidityTypes() },
           },
           required: ['name', 'type'],
         },
@@ -75,6 +75,21 @@ export const TYPED_MESSAGE_SCHEMA = {
   },
   required: ['types', 'primaryType', 'domain', 'message'],
 };
+
+function getSolidityTypes() {
+  const types = ['bool', 'address', 'int', 'uint', 'string', 'byte'];
+  const ints = Array.from(new Array(32)).map(
+    (_, index) => `int${(index + 1) * 8}`,
+  );
+  const uints = Array.from(new Array(32)).map(
+    (_, index) => `uint${(index + 1) * 8}`,
+  );
+  const bytes = Array.from(new Array(32)).map(
+    (_, index) => `bytes${index + 1}`,
+  );
+
+  return types.concat(ints).concat(uints).concat(bytes);
+}
 
 /**
  * Encodes an object by encoding and concatenating each of its members

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export const TYPED_MESSAGE_SCHEMA = {
 };
 
 function getSolidityTypes() {
-  const types = ['bool', 'address', 'int', 'uint', 'string', 'byte'];
+  const types = ['bool', 'address', 'string', 'bytes'];
   const ints = Array.from(new Array(32)).map(
     (_, index) => `int${(index + 1) * 8}`,
   );
@@ -88,7 +88,7 @@ function getSolidityTypes() {
     (_, index) => `bytes${index + 1}`,
   );
 
-  return types.concat(ints).concat(uints).concat(bytes);
+  return [...types, ...ints, ...uints, ...bytes];
 }
 
 /**


### PR DESCRIPTION
The solidity types supported by EIP-712 have been added to the typed message JSON schema.

This was originally proposed in #31; see there for more details.