### PR TITLE
Fix `concatSig` parameter and handling of return value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -428,7 +428,7 @@ export function personalSign<T extends MessageTypes>(
   const message = ethUtil.toBuffer(msgParams.data);
   const msgHash = ethUtil.hashPersonalMessage(message);
   const sig = ethUtil.ecsign(msgHash, privateKey);
-  const serialized = ethUtil.bufferToHex(concatSig(sig.v, sig.r, sig.s));
+  const serialized = concatSig(ethUtil.toBuffer(sig.v), sig.r, sig.s);
   return serialized;
 }
 
@@ -699,7 +699,7 @@ export function signTypedData<T extends MessageTypes>(
       ? _typedSignatureHash(msgParams.data)
       : TypedDataUtils.eip712Hash(msgParams.data, version);
   const sig = ethUtil.ecsign(messageHash, privateKey);
-  return ethUtil.bufferToHex(concatSig(sig.v, sig.r, sig.s));
+  return concatSig(ethUtil.toBuffer(sig.v), sig.r, sig.s);
 }
 
 /**


### PR DESCRIPTION
The `v` parameter of the `concatSig` function was being passed in as a `number`, but it was supposed to be a `Buffer`. It is now converted to `Buffer` before being passed in. This should not be a functional change.

The return value was being treated as a `Buffer`, but it was a hex-prefixed string. The useless Buffer-to-hex-string conversion step has been removed.