### PR TITLE
Remove `signTypedData` version `V2`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ interface EIP712TypedData {
   value: any;
 }
 
-export type Version = 'V1' | 'V2' | 'V3' | 'V4';
+export type Version = 'V1' | 'V3' | 'V4';
 
 export interface EthEncryptedData {
   version: string;


### PR DESCRIPTION
This version was never documented or supported. In effect if anyone was using this, they were using `V3`.