### PR TITLE
Add validation to check that parameters aren't nullish

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4272,6 +4272,122 @@ describe('personalSign', function () {
       _expect(recovered).toBe(addressHex);
     });
   }
+
+  describe('validation', function () {
+    describe('personalSign', function () {
+      it('should throw if passed null data', function () {
+        expect(() =>
+          sigUtil.personalSign({
+            privateKey,
+            data: null,
+          }),
+        ).toThrow('Missing data parameter');
+      });
+
+      it('should throw if passed undefined data', function () {
+        expect(() =>
+          sigUtil.personalSign({
+            privateKey,
+            data: undefined,
+          }),
+        ).toThrow('Missing data parameter');
+      });
+
+      it('should throw if passed a null private key', function () {
+        expect(() =>
+          sigUtil.personalSign({
+            privateKey: null,
+            data: helloWorldMessage,
+          }),
+        ).toThrow('Missing privateKey parameter');
+      });
+
+      it('should throw if passed an undefined private key', function () {
+        expect(() =>
+          sigUtil.personalSign({
+            privateKey: undefined,
+            data: helloWorldMessage,
+          }),
+        ).toThrow('Missing privateKey parameter');
+      });
+    });
+
+    describe('recoverPersonalSignature', function () {
+      it('should throw if passed null data', function () {
+        expect(() =>
+          sigUtil.recoverPersonalSignature({
+            data: null,
+            signature: helloWorldSignature,
+          }),
+        ).toThrow('Missing data parameter');
+      });
+
+      it('should throw if passed undefined data', function () {
+        expect(() =>
+          sigUtil.recoverPersonalSignature({
+            data: undefined,
+            signature: helloWorldSignature,
+          }),
+        ).toThrow('Missing data parameter');
+      });
+
+      it('should throw if passed a null signature', function () {
+        expect(() =>
+          sigUtil.recoverPersonalSignature({
+            data: helloWorldMessage,
+            signature: null,
+          }),
+        ).toThrow('Missing signature parameter');
+      });
+
+      it('should throw if passed an undefined signature', function () {
+        expect(() =>
+          sigUtil.recoverPersonalSignature({
+            data: helloWorldMessage,
+            signature: undefined,
+          }),
+        ).toThrow('Missing signature parameter');
+      });
+    });
+
+    describe('extractPublicKey', function () {
+      it('should throw if passed null data', function () {
+        expect(() =>
+          sigUtil.extractPublicKey({
+            data: null,
+            signature: helloWorldSignature,
+          }),
+        ).toThrow('Missing data parameter');
+      });
+
+      it('should throw if passed undefined data', function () {
+        expect(() =>
+          sigUtil.extractPublicKey({
+            data: undefined,
+            signature: helloWorldSignature,
+          }),
+        ).toThrow('Missing data parameter');
+      });
+
+      it('should throw if passed a null signature', function () {
+        expect(() =>
+          sigUtil.extractPublicKey({
+            data: helloWorldMessage,
+            signature: null,
+          }),
+        ).toThrow('Missing signature parameter');
+      });
+
+      it('should throw if passed an undefined signature', function () {
+        expect(() =>
+          sigUtil.extractPublicKey({
+            data: helloWorldMessage,
+            signature: undefined,
+          }),
+        ).toThrow('Missing signature parameter');
+      });
+    });
+  });
 });
 
 // Comments starting with "V1:" highlight differences relative to V3 and 4.
@@ -6257,14 +6373,56 @@ describe('signTypedData', function () {
     });
   });
 
-  it('should throw if passed an invalid version', () => {
-    expect(() =>
-      sigUtil.signTypedData({
-        privateKey,
-        data: [{ name: 'data', type: 'string', value: 'Hello!' }],
-        version: 'V0' as any,
-      }),
-    ).toThrow('Invalid version');
+  describe('validation', () => {
+    it('should throw if passed an invalid version', () => {
+      expect(() =>
+        sigUtil.signTypedData({
+          privateKey,
+          data: [{ name: 'data', type: 'string', value: 'Hello!' }],
+          version: 'V0' as any,
+        }),
+      ).toThrow('Invalid version');
+    });
+
+    it('should throw if passed null data', () => {
+      expect(() =>
+        sigUtil.signTypedData({
+          privateKey,
+          data: null,
+          version: Version.V1,
+        }),
+      ).toThrow('Missing data parameter');
+    });
+
+    it('should throw if passed undefined data', () => {
+      expect(() =>
+        sigUtil.signTypedData({
+          privateKey,
+          data: undefined,
+          version: Version.V1,
+        }),
+      ).toThrow('Missing data parameter');
+    });
+
+    it('should throw if passed a null private key', () => {
+      expect(() =>
+        sigUtil.signTypedData({
+          privateKey: null,
+          data: [{ name: 'data', type: 'string', value: 'Hello!' }],
+          version: Version.V1,
+        }),
+      ).toThrow('Missing private key parameter');
+    });
+
+    it('should throw if passed an undefined private key', () => {
+      expect(() =>
+        sigUtil.signTypedData({
+          privateKey: undefined,
+          data: [{ name: 'data', type: 'string', value: 'Hello!' }],
+          version: Version.V1,
+        }),
+      ).toThrow('Missing private key parameter');
+    });
   });
 });
 
@@ -6440,19 +6598,61 @@ describe('recoverTypedSignature', function () {
     });
   });
 
-  it('should throw if passed an invalid version', () => {
+  describe('validation', () => {
     // This is a signature of the message "[{ name: 'message', type: 'string', value: 'Hi, Alice!' }]"
     // that was created using the private key in the top-level `privateKey` variable.
     const exampleSignature =
       '0x49e75d475d767de7fcc67f521e0d86590723d872e6111e51c393e8c1e2f21d032dfaf5833af158915f035db6af4f37bf2d5d29781cd81f28a44c5cb4b9d241531b';
 
-    expect(() =>
-      sigUtil.recoverTypedSignature({
-        data: [{ name: 'message', type: 'string', value: 'Hi, Alice!' }],
-        signature: exampleSignature,
-        version: 'V0' as any,
-      }),
-    ).toThrow('Invalid version');
+    it('should throw if passed an invalid version', () => {
+      expect(() =>
+        sigUtil.recoverTypedSignature({
+          data: [{ name: 'message', type: 'string', value: 'Hi, Alice!' }],
+          signature: exampleSignature,
+          version: 'V0' as any,
+        }),
+      ).toThrow('Invalid version');
+    });
+
+    it('should throw if passed null data', () => {
+      expect(() =>
+        sigUtil.recoverTypedSignature({
+          data: null,
+          signature: exampleSignature,
+          version: Version.V1,
+        }),
+      ).toThrow('Missing data parameter');
+    });
+
+    it('should throw if passed undefined data', () => {
+      expect(() =>
+        sigUtil.recoverTypedSignature({
+          data: undefined,
+          signature: exampleSignature,
+          version: Version.V1,
+        }),
+      ).toThrow('Missing data parameter');
+    });
+
+    it('should throw if passed a null signature', () => {
+      expect(() =>
+        sigUtil.recoverTypedSignature({
+          data: [{ name: 'message', type: 'string', value: 'Hi, Alice!' }],
+          signature: null,
+          version: Version.V1,
+        }),
+      ).toThrow('Missing signature parameter');
+    });
+
+    it('should throw if passed a null signature', () => {
+      expect(() =>
+        sigUtil.recoverTypedSignature({
+          data: [{ name: 'message', type: 'string', value: 'Hi, Alice!' }],
+          signature: undefined,
+          version: Version.V1,
+        }),
+      ).toThrow('Missing signature parameter');
+    });
   });
 });
 
@@ -6716,5 +6916,207 @@ describe('encryption', function () {
         privateKey: bob.ethereumPrivateKey,
       }),
     ).toThrow('Decryption failed.');
+  });
+
+  describe('validation', function () {
+    describe('encrypt', function () {
+      it('should throw if passed null public key', function () {
+        expect(() =>
+          sigUtil.encrypt({
+            publicKey: null,
+            data: secretMessage,
+            version: 'x25519-xsalsa20-poly1305',
+          }),
+        ).toThrow('Missing publicKey parameter');
+      });
+
+      it('should throw if passed undefined public key', function () {
+        expect(() =>
+          sigUtil.encrypt({
+            publicKey: undefined,
+            data: secretMessage,
+            version: 'x25519-xsalsa20-poly1305',
+          }),
+        ).toThrow('Missing publicKey parameter');
+      });
+
+      it('should throw if passed null data', function () {
+        expect(() =>
+          sigUtil.encrypt({
+            publicKey: bob.encryptionPublicKey,
+            data: null,
+            version: 'x25519-xsalsa20-poly1305',
+          }),
+        ).toThrow('Missing data parameter');
+      });
+
+      it('should throw if passed undefined data', function () {
+        expect(() =>
+          sigUtil.encrypt({
+            publicKey: bob.encryptionPublicKey,
+            data: undefined,
+            version: 'x25519-xsalsa20-poly1305',
+          }),
+        ).toThrow('Missing data parameter');
+      });
+
+      it('should throw if passed null version', function () {
+        expect(() =>
+          sigUtil.encrypt({
+            publicKey: bob.encryptionPublicKey,
+            data: secretMessage,
+            version: null,
+          }),
+        ).toThrow('Missing version parameter');
+      });
+
+      it('should throw if passed undefined version', function () {
+        expect(() =>
+          sigUtil.encrypt({
+            publicKey: bob.encryptionPublicKey,
+            data: secretMessage,
+            version: undefined,
+          }),
+        ).toThrow('Missing version parameter');
+      });
+    });
+
+    describe('encryptSafely', function () {
+      it('should throw if passed null public key', function () {
+        expect(() =>
+          sigUtil.encryptSafely({
+            publicKey: null,
+            data: secretMessage,
+            version: 'x25519-xsalsa20-poly1305',
+          }),
+        ).toThrow('Missing publicKey parameter');
+      });
+
+      it('should throw if passed undefined public key', function () {
+        expect(() =>
+          sigUtil.encryptSafely({
+            publicKey: undefined,
+            data: secretMessage,
+            version: 'x25519-xsalsa20-poly1305',
+          }),
+        ).toThrow('Missing publicKey parameter');
+      });
+
+      it('should throw if passed null data', function () {
+        expect(() =>
+          sigUtil.encryptSafely({
+            publicKey: bob.encryptionPublicKey,
+            data: null,
+            version: 'x25519-xsalsa20-poly1305',
+          }),
+        ).toThrow('Missing data parameter');
+      });
+
+      it('should throw if passed undefined data', function () {
+        expect(() =>
+          sigUtil.encryptSafely({
+            publicKey: bob.encryptionPublicKey,
+            data: undefined,
+            version: 'x25519-xsalsa20-poly1305',
+          }),
+        ).toThrow('Missing data parameter');
+      });
+
+      it('should throw if passed null version', function () {
+        expect(() =>
+          sigUtil.encryptSafely({
+            publicKey: bob.encryptionPublicKey,
+            data: secretMessage,
+            version: null,
+          }),
+        ).toThrow('Missing version parameter');
+      });
+
+      it('should throw if passed undefined version', function () {
+        expect(() =>
+          sigUtil.encryptSafely({
+            publicKey: bob.encryptionPublicKey,
+            data: secretMessage,
+            version: undefined,
+          }),
+        ).toThrow('Missing version parameter');
+      });
+    });
+
+    describe('decrypt', function () {
+      it('should throw if passed null encrypted data', function () {
+        expect(() =>
+          sigUtil.decrypt({
+            encryptedData: null,
+            privateKey: bob.ethereumPrivateKey,
+          }),
+        ).toThrow('Missing encryptedData parameter');
+      });
+
+      it('should throw if passed undefined encrypted data', function () {
+        expect(() =>
+          sigUtil.decrypt({
+            encryptedData: undefined,
+            privateKey: bob.ethereumPrivateKey,
+          }),
+        ).toThrow('Missing encryptedData parameter');
+      });
+
+      it('should throw if passed null private key', function () {
+        expect(() =>
+          sigUtil.decrypt({
+            encryptedData,
+            privateKey: null,
+          }),
+        ).toThrow('Missing privateKey parameter');
+      });
+
+      it('should throw if passed undefined private key', function () {
+        expect(() =>
+          sigUtil.decrypt({
+            encryptedData,
+            privateKey: undefined,
+          }),
+        ).toThrow('Missing privateKey parameter');
+      });
+    });
+
+    describe('decryptSafely', function () {
+      it('should throw if passed null encrypted data', function () {
+        expect(() =>
+          sigUtil.decryptSafely({
+            encryptedData: null,
+            privateKey: bob.ethereumPrivateKey,
+          }),
+        ).toThrow('Missing encryptedData parameter');
+      });
+
+      it('should throw if passed undefined encrypted data', function () {
+        expect(() =>
+          sigUtil.decryptSafely({
+            encryptedData: undefined,
+            privateKey: bob.ethereumPrivateKey,
+          }),
+        ).toThrow('Missing encryptedData parameter');
+      });
+
+      it('should throw if passed null private key', function () {
+        expect(() =>
+          sigUtil.decryptSafely({
+            encryptedData,
+            privateKey: null,
+          }),
+        ).toThrow('Missing privateKey parameter');
+      });
+
+      it('should throw if passed undefined private key', function () {
+        expect(() =>
+          sigUtil.decryptSafely({
+            encryptedData,
+            privateKey: undefined,
+          }),
+        ).toThrow('Missing privateKey parameter');
+      });
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,16 @@ function validateVersion(version: Version, allowedVersions?: Version[]) {
 }
 
 /**
+ * Returns `true` if the given value is nullish.
+ *
+ * @param value - The value being checked.
+ * @returns Whether the value is nullish.
+ */
+function isNullish(value) {
+  return value === null || value === undefined;
+}
+
+/**
  * Encode a single field.
  *
  * @param types - All type definitions.
@@ -473,6 +483,12 @@ export function personalSign({
   privateKey: Buffer;
   data: unknown;
 }): string {
+  if (isNullish(data)) {
+    throw new Error('Missing data parameter');
+  } else if (isNullish(privateKey)) {
+    throw new Error('Missing privateKey parameter');
+  }
+
   const message = legacyToBuffer(data);
   const msgHash = ethUtil.hashPersonalMessage(message);
   const sig = ethUtil.ecsign(msgHash, privateKey);
@@ -496,6 +512,12 @@ export function recoverPersonalSignature({
   data: unknown;
   signature: string;
 }): string {
+  if (isNullish(data)) {
+    throw new Error('Missing data parameter');
+  } else if (isNullish(signature)) {
+    throw new Error('Missing signature parameter');
+  }
+
   const publicKey = getPublicKeyFor(data, signature);
   const sender = ethUtil.publicToAddress(publicKey);
   const senderHex = ethUtil.bufferToHex(sender);
@@ -518,6 +540,12 @@ export function extractPublicKey({
   data: unknown;
   signature: string;
 }): string {
+  if (isNullish(data)) {
+    throw new Error('Missing data parameter');
+  } else if (isNullish(signature)) {
+    throw new Error('Missing signature parameter');
+  }
+
   const publicKey = getPublicKeyFor(data, signature);
   return `0x${publicKey.toString('hex')}`;
 }
@@ -554,6 +582,14 @@ export function encrypt({
   data: unknown;
   version: string;
 }): EthEncryptedData {
+  if (isNullish(publicKey)) {
+    throw new Error('Missing publicKey parameter');
+  } else if (isNullish(data)) {
+    throw new Error('Missing data parameter');
+  } else if (isNullish(version)) {
+    throw new Error('Missing version parameter');
+  }
+
   switch (version) {
     case 'x25519-xsalsa20-poly1305': {
       if (typeof data !== 'string') {
@@ -618,12 +654,16 @@ export function encryptSafely({
   data: unknown;
   version: string;
 }): EthEncryptedData {
+  if (isNullish(publicKey)) {
+    throw new Error('Missing publicKey parameter');
+  } else if (isNullish(data)) {
+    throw new Error('Missing data parameter');
+  } else if (isNullish(version)) {
+    throw new Error('Missing version parameter');
+  }
+
   const DEFAULT_PADDING_LENGTH = 2 ** 11;
   const NACL_EXTRA_BYTES = 16;
-
-  if (!data) {
-    throw new Error('Cannot encrypt empty data');
-  }
 
   if (typeof data === 'object' && 'toJSON' in data) {
     // remove toJSON attack vector
@@ -671,6 +711,12 @@ export function decrypt({
   encryptedData: EthEncryptedData;
   privateKey: string;
 }): string {
+  if (isNullish(encryptedData)) {
+    throw new Error('Missing encryptedData parameter');
+  } else if (isNullish(privateKey)) {
+    throw new Error('Missing privateKey parameter');
+  }
+
   switch (encryptedData.version) {
     case 'x25519-xsalsa20-poly1305': {
       // string to buffer to UInt8Array
@@ -728,6 +774,12 @@ export function decryptSafely({
   encryptedData: EthEncryptedData;
   privateKey: string;
 }): string {
+  if (isNullish(encryptedData)) {
+    throw new Error('Missing encryptedData parameter');
+  } else if (isNullish(privateKey)) {
+    throw new Error('Missing privateKey parameter');
+  }
+
   const dataWithPadding = JSON.parse(decrypt({ encryptedData, privateKey }));
   return dataWithPadding.data;
 }
@@ -774,6 +826,11 @@ export function signTypedData<V extends Version, T extends MessageTypes>({
   version: V;
 }): string {
   validateVersion(version);
+  if (isNullish(data)) {
+    throw new Error('Missing data parameter');
+  } else if (isNullish(privateKey)) {
+    throw new Error('Missing private key parameter');
+  }
 
   const messageHash =
     version === Version.V1
@@ -810,6 +867,11 @@ export function recoverTypedSignature<
   version: V;
 }): string {
   validateVersion(version);
+  if (isNullish(data)) {
+    throw new Error('Missing data parameter');
+  } else if (isNullish(signature)) {
+    throw new Error('Missing signature parameter');
+  }
 
   const messageHash =
     version === Version.V1


### PR DESCRIPTION
Validation has been added to the signing and encryption functions to ensure that the parameters are not nullish. This should help with migrating from the last major version, as it would be easy to accidentally use the wrong parameter name when migrating.

A nullish check was used rather than a falsy check because there are falsy values that are valid for some parameters (e.g. the data being signed can be `0`). `null` and `undefined` are never valid in these cases though.