### PR TITLE
Fix missing parameter descriptions in docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "tweetnacl-util": "^0.15.1"
   },
   "devDependencies": {
+    "@gudahtt/typedoc": "^0.23.0",
     "@lavamoat/allow-scripts": "^1.0.6",
     "@metamask/auto-changelog": "^2.4.0",
     "@metamask/eslint-config": "^7.0.1",
@@ -66,7 +67,6 @@
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.0.3",
-    "typedoc": "^0.22.3",
     "typescript": "^4.1.3"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,6 +333,17 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@gudahtt/typedoc@^0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@gudahtt/typedoc/-/typedoc-0.23.0.tgz#638e78511a05d8c86478771d2ee8b88311aeb630"
+  integrity sha512-DjyjyqVar9fEbhc62qjFH2Sp8+xBbFGS1NtpNfUtj2cfwWwNnn73oLSArc0cSvyGpKi97sZmr7Zu4Q9sEzV3mQ==
+  dependencies:
+    glob "^7.1.7"
+    lunr "^2.3.9"
+    marked "^3.0.4"
+    minimatch "^3.0.4"
+    shiki "^0.9.11"
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -3512,7 +3523,7 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-marked@^3.0.3:
+marked@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/marked/-/marked-3.0.4.tgz#b8a1539e5e05c6ea9e93f15c0bad1d54ce890406"
   integrity sha512-jBo8AOayNaEcvBhNobg6/BLhdsK3NvnKWJg33MAAPbvTWiG4QBn9gpW1+7RssrKu4K1dKlN+0goVQwV41xEfOA==
@@ -4312,7 +4323,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shiki@^0.9.10:
+shiki@^0.9.11:
   version "0.9.11"
   resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.9.11.tgz#07d75dab2abb6dc12a01f79a397cb1c391fa22d8"
   integrity sha512-tjruNTLFhU0hruCPoJP0y+B9LKOmcqUhTpxn7pcJB3fa+04gFChuEmxmrUfOJ7ZO6Jd+HwMnDHgY3lv3Tqonuw==
@@ -4795,17 +4806,6 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
-
-typedoc@^0.22.3:
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.22.3.tgz#c67aaeef22702d84267bda12dc13f192dbf9d89e"
-  integrity sha512-EOWf9Vf3Vfb/jzBzr87uoLybQw9fx3iyXLUcpQn9F2Ks1/ZJN9iGeBbYRU+VNqrWvV4T+aS7Ife7GFEJUf0ohQ==
-  dependencies:
-    glob "^7.1.7"
-    lunr "^2.3.9"
-    marked "^3.0.3"
-    minimatch "^3.0.4"
-    shiki "^0.9.10"
 
 typescript@^4.1.3:
   version "4.1.3"


### PR DESCRIPTION
The parameter descriptions were missing for any destructured parameters. Apparently TypeDoc doesn't support showing descriptions for destructured parameters ([see here for more details](https://github.com/TypeStrong/typedoc/issues/1703)).

I have forked TypeDoc to fix this problem, and published this fork as `@gudahtt/typedoc@0.23.0`. We can use this fork until this has been resolved upstream.