### PR TITLE
Replace README API docs with generated docs

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -1,0 +1,43 @@
+name: Publish to GitHub Pages
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  publish-gh-pages:
+    permissions:
+      contents: write
+    # The second argument to startsWith() must match the release-branch-prefix
+    # input to this Action. Here, we use the default, "release/".
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Node.js version
+        id: nvm
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+      - name: Get Yarn cache directory
+        run: echo "::set-output name=YARN_CACHE_DIR::$(yarn cache dir)"
+        id: yarn-cache-dir
+      - name: Get Yarn version
+        run: echo "::set-output name=YARN_VERSION::$(yarn --version)"
+        id: yarn-version
+      - name: Cache yarn dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.YARN_CACHE_DIR }}
+          key: yarn-cache-${{ runner.os }}-${{ steps.yarn-version.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}
+      - run: yarn --frozen-lockfile
+      - run: yarn allow-scripts
+      - uses: MetaMask/action-publish-gh-pages@v1
+        with:
+          npm-build-command: docs:publish
+          directory: docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,57 +14,9 @@ or
 
 `npm install @metamask/eth-sig-util`
 
-## Methods
+## API
 
-### concatSig(v, r, s)
-
-All three arguments should be provided as buffers.
-
-Returns a continuous, hex-prefixed hex value for the signature, suitable for inclusion in a JSON transaction's data field.
-
-### normalize(address)
-
-Takes an address of either upper or lower case, with or without a hex prefix, and returns an all-lowercase, hex-prefixed address, suitable for submitting to an ethereum provider.
-
-### personalSign (privateKeyBuffer, msgParams)
-
-msgParams should have a `data` key that is hex-encoded data to sign.
-
-Returns the prefixed signature expected for calls to `eth.personalSign`.
-
-### recoverPersonalSignature (msgParams)
-
-msgParams should have a `data` key that is hex-encoded data unsigned, and a `sig` key that is hex-encoded and already signed.
-
-Returns a hex-encoded sender address.
-
-### signTypedData (privateKeyBuffer, msgParams, version)
-
-Sign typed data according to EIP-712. The signing differs based upon the `version`, which is explained in the table below.
-
-Data should be under `data` key of `msgParams`. The method returns prefixed signature.
-
-| Version | Description                                                  |
-| ------- | ------------------------------------------------------------ |
-| `V1`    | This is based on [an early version of EIP-712](https://github.com/ethereum/EIPs/pull/712/commits/21abe254fe0452d8583d5b132b1d7be87c0439ca) that lacked some later security improvements, and should generally be neglected in favor of `V3`. |
-| `V3`    | Based on [EIP 712](https://eips.ethereum.org/EIPS/eip-712), except that arrays and recursive data structures are not supported |
-| `V4`    | Based on [EIP 712](https://eips.ethereum.org/EIPS/eip-712), including support for arrays and recursive data types. |
-
-### recoverTypedSignature ({data, sig}, version)
-
-Recover the address of the account used to sign the provided signature. The `version` parameter must match the version the signature was created with.
-
-Expects the same data that were used for signing. `sig` is a prefixed signature.
-
-### typedSignatureHash (typedData)
-
-Return hex-encoded hash of typed data params according to [EIP712](https://github.com/ethereum/EIPs/pull/712) schema.
-
-### extractPublicKey (msgParams)
-
-msgParams should have a `data` key that is hex-encoded data unsigned, and a `sig` key that is hex-encoded and already signed.
-
-Returns a hex-encoded public key.
+The full API documentation for the latest published version of this library is [available here](https://metamask.github.io/eth-sig-util/index.html).
 
 ## Contributing
 
@@ -81,6 +33,10 @@ Returns a hex-encoded public key.
 Run `yarn test` to run the tests once. To run tests on file changes, run `yarn test:watch`.
 
 Run `yarn lint` to run the linter, or run `yarn lint:fix` to run the linter and fix any automatically fixable issues.
+
+### Documentation
+
+The API documentation can be generated with the command `yarn docs`, which saves it in the `./docs` directory. Open the `./docs/index.html` file to browse the documentation.
 
 ### Release & Publishing
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "prepublishOnly": "yarn build:clean",
-    "docs": "typedoc"
+    "docs": "typedoc",
+    "docs:publish": "typedoc --cleanOutputDir false --gitRevision \"v$(jq -r .version < ./package.json)\""
   },
   "resolutions": {
     "airtap/engine.io-client/xmlhttprequest-ssl": "^1.6.2"

--- a/src/personal-sign.ts
+++ b/src/personal-sign.ts
@@ -21,8 +21,8 @@ import {
  *
  * @param options - The personal sign options.
  * @param options.privateKey - The key to sign with.
- * @param options.data - The data to sign.
- * @returns The signature.
+ * @param options.data - The hex data to sign.
+ * @returns The '0x'-prefixed hex encoded signature.
  */
 export function personalSign({
   privateKey,
@@ -49,9 +49,9 @@ export function personalSign({
  * must have been signed using the `personalSign` function, or an equivalent function.
  *
  * @param options - The signature recovery options.
- * @param options.data - The message that was signed.
- * @param options.signature - The signature for the message.
- * @returns The address of the message signer.
+ * @param options.data - The hex data that was signed.
+ * @param options.signature - The '0x'-prefixed hex encoded message signature.
+ * @returns The '0x'-prefixed hex encoded address of the message signer.
  */
 export function recoverPersonalSignature({
   data,
@@ -77,9 +77,9 @@ export function recoverPersonalSignature({
  * must have been signed using the `personalSign` function, or an equivalent function.
  *
  * @param options - The public key recovery options.
- * @param options.data - The message that was signed.
- * @param options.signature - The signature for the message.
- * @returns The public key of the message signer.
+ * @param options.data - The hex data that was signed.
+ * @param options.signature - The '0x'-prefixed hex encoded message signature.
+ * @returns The '0x'-prefixed hex encoded public key of the message signer.
  */
 export function extractPublicKey({
   data,
@@ -102,7 +102,7 @@ export function extractPublicKey({
  * Get the public key for the given signature and message.
  *
  * @param message - The message that was signed.
- * @param signature - The signature.
+ * @param signature - The '0x'-prefixed hex encoded message signature.
  * @returns The public key of the signer.
  */
 function getPublicKeyFor(message: unknown, signature: string): Buffer {

--- a/src/sign-typed-data.ts
+++ b/src/sign-typed-data.ts
@@ -32,6 +32,17 @@ export interface EIP712TypedData {
   value: any;
 }
 
+/**
+ * Represents the version of `signTypedData` being used.
+ *
+ * V1 is based upon [an early version of EIP-712](https://github.com/ethereum/EIPs/pull/712/commits/21abe254fe0452d8583d5b132b1d7be87c0439ca)
+ * that lacked some later security improvements, and should generally be neglected in favor of
+ * later versions.
+ *
+ * V3 is based on EIP-712, except that arrays and recursive data structures are not supported.
+ *
+ * V4 is based on EIP-712, and includes full support of arrays and recursive data structures.
+ */
 export enum Version {
   V1 = 'V1',
   V3 = 'V3',
@@ -401,7 +412,7 @@ function eip712Hash<T extends MessageTypes>(
 }
 
 /**
- * A collection of utility functions used for signing typed data
+ * A collection of utility functions used for signing typed data.
  */
 export const TypedDataUtils = {
   encodeData,
@@ -420,7 +431,7 @@ export const TypedDataUtils = {
  * specification. This hash is used in `signTypedData_v1`.
  *
  * @param typedData - The typed message.
- * @returns The type hash for the provided message.
+ * @returns The '0x'-prefixed hex encoded hash representing the type of the provided message.
  */
 export function typedSignatureHash(typedData: EIP712TypedData[]): string {
   const hashBuffer = _typedSignatureHash(typedData);
@@ -434,7 +445,7 @@ export function typedSignatureHash(typedData: EIP712TypedData[]): string {
  * specification. This hash is used in `signTypedData_v1`.
  *
  * @param typedData - The typed message.
- * @returns The type hash for the provided message.
+ * @returns The hash representing the type of the provided message.
  */
 function _typedSignatureHash(typedData: TypedDataV1): Buffer {
   const error = new Error('Expect argument to be non-empty array');
@@ -476,20 +487,20 @@ function _typedSignatureHash(typedData: TypedDataV1): Buffer {
  * Sign typed data according to EIP-712. The signing differs based upon the `version`.
  *
  * V1 is based upon [an early version of EIP-712](https://github.com/ethereum/EIPs/pull/712/commits/21abe254fe0452d8583d5b132b1d7be87c0439ca)
- * that lacked some later security improvements, and should generally be
- * neglected in favor of later versions.
+ * that lacked some later security improvements, and should generally be neglected in favor of
+ * later versions.
  *
- * V3 is based on EIP-712, except that arrays and recursive data structures
- * are not supported.
+ * V3 is based on [EIP-712](https://eips.ethereum.org/EIPS/eip-712), except that arrays and
+ * recursive data structures are not supported.
  *
- * V4 is based on EIP-712, and includes full support of arrays and recursive
- * data structures.
+ * V4 is based on [EIP-712](https://eips.ethereum.org/EIPS/eip-712), and includes full support of
+ * arrays and recursive data structures.
  *
  * @param options - The signing options.
  * @param options.privateKey - The private key to sign with.
  * @param options.data - The typed data to sign.
  * @param options.version - The signing version to use.
- * @returns The signature.
+ * @returns The '0x'-prefixed hex encoded signature.
  */
 export function signTypedData<V extends Version, T extends MessageTypes>({
   privateKey,
@@ -524,10 +535,10 @@ export function signTypedData<V extends Version, T extends MessageTypes>({
  * create the signature.
  *
  * @param options - The signature recovery options.
- * @param options.data - The data that was signed.
- * @param options.signature - The message signature.
+ * @param options.data - The typed data that was signed.
+ * @param options.signature - The '0x-prefixed hex encoded message signature.
  * @param options.version - The signing version to use.
- * @returns The address of the signer.
+ * @returns The '0x'-prefixed hex address of the signer.
  */
 export function recoverTypedSignature<
   V extends Version,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,12 +63,12 @@ export function legacyToBuffer(value: unknown) {
 }
 
 /**
- * Concatenate an extended ECDSA signature into a hex string.
+ * Concatenate an extended ECDSA signature into a single '0x'-prefixed hex string.
  *
  * @param v - The 'v' portion of the signature.
  * @param r - The 'r' portion of the signature.
  * @param s - The 's' portion of the signature.
- * @returns The concatenated ECDSA signature.
+ * @returns The concatenated ECDSA signature as a '0x'-prefixed string.
  */
 export function concatSig(v: Buffer, r: Buffer, s: Buffer): string {
   const rSig = fromSigned(r);
@@ -96,10 +96,10 @@ export function recoverPublicKey(
 }
 
 /**
- * Normalize the input to a 0x-prefixed hex string.
+ * Normalize the input to a lower-cased '0x'-prefixed hex string.
  *
  * @param input - The value to normalize.
- * @returns The normalized 0x-prefixed hex string.
+ * @returns The normalized value.
  */
 export function normalize(input: number | string): string {
   if (!input) {


### PR DESCRIPTION
The API documentation in the README has been replaced with GitHub-pages hosted documentation generated using TypeDoc.

The `@MetaMask/action-publish-gh-pages` action is used for the publish step. The action configuration is taken nearly exactly from the README example for that action, except that the build command and directory are updated, and the `yarn setup` step has been added (because TypeDoc needs to be installed).

A new `docs:publish` npm script has been added to ensure the output directory doesn't get cleaned (because it includes the `git worktree` setup by the `@MetaMask/action-publish-gh-pages` action), and to set the correct git revision.

These docs will only be published when the package is released, rather than the latest development version. Instructions have been added to the contributing section showing how to generate and view the API documentation for the current commit.

The old README API documentation has been reviewed and incorporated into the inline documentation. Minor adjustments and improvements have been made to ensure that no information is lost.

Closes #47