### PR TITLE
Add subpath exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,13 @@
   },
   "license": "ISC",
   "author": "Dan Finlay",
-  "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./encryption": "./dist/encryption.js",
+    "./personal-sign": "./dist/personal-sign.js",
+    "./sign-typed-data": "./dist/sign-typed-data.js"
+  },
+  "main": "./dist/index.js",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Subpath exports have been added for the three "main" modules in this package. These allow consumers to easily omit the parts of the package they aren't using, without risking accidentally relying upon internal APIs.

The three main "feature" modules have been exposed as subpath exports. The "util" module is the only one not exported, and that's because its API includes methods that we don't want to include in the public API of the package. We can separate the internal and external "util" methods later on if there is any demand for this.