### PR TITLE
Use hex data for `personalSign` tests

### DIFF
--- a/src/personal-sign.test.ts
+++ b/src/personal-sign.test.ts
@@ -20,7 +20,7 @@ describe('personalSign', function () {
   // the top-level `privateKey` variable.
   const helloWorldSignature =
     '0x90a938f7457df6e8f741264c32697fc52f9a8f867c52dd70713d9d2d472f2e415d9c94148991bbe1f4a1818d1dff09165782749c877f5cf1eff4ef126e55714d1c';
-  const helloWorldMessage = 'Hello, world!';
+  const helloWorldMessage = `0x${Buffer.from('Hello, world!').toString('hex')}`;
 
   it('should sign a message', function () {
     expect(personalSign({ privateKey, data: helloWorldMessage })).toBe(


### PR DESCRIPTION
The data passed to `personalSign` should be hex-encoded according to the documentation, but in practice we will accept any type of data that we can parse into bytes using our `toBuffer` function.

We want users of this library to pass in hex-encoded data though, because how we interpret non-hex data is ambiguous and might lead to misunderstandings or incompatibilities. The unit tests have been updated to use hex data exclusively, so that if anyone looks to them for an example of how to use the library, they will not be mislead into passing in raw strings.

We should add more unit tests later to test how `personalSign` handles non-hex data inputs, but that was not the intended purpose of any of these unit tests.

Closes #34