### PR TITLE
Prevent tests from being compiled

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "typeRoots": ["./node_modules/@types"]
   },
   "include": ["./src/**/*.ts"],
-  "exclude": ["**/*.test.js"]
+  "exclude": ["**/*.test.ts"]
 }


### PR DESCRIPTION
A mistake in `tsconfig.json` resulted in tests being compiled when `yarn build` was run. The tests should now be correctly ignored when building.