### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,10 @@ The full API documentation for the latest published version of this library is [
 
 ### Setup
 
-- Install [Node.js](https://nodejs.org) version 12
+- Install [Node.js](https://nodejs.org) version 14
   - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
-- Install [Yarn v1](https://yarnpkg.com/en/docs/install)
-- Run `yarn setup` to install dependencies and run any required post-install scripts
-  - **Warning:** Do not use the `yarn` / `yarn install` command directly. Use `yarn setup` instead. The normal install command will skip required post-install scripts, leaving your development environment in an invalid state.
+- Install [Yarn v3](https://yarnpkg.com/getting-started/install)
+- Run `yarn install` to install dependencies and run any required post-install scripts
 
 ### Testing and Linting
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' '!.yarnrc.yml' --ignore-path .gitignore --no-error-on-unmatched-pattern",
     "prepack": "./scripts/prepack.sh",
-    "setup": "yarn install",
     "test": "jest",
     "test:watch": "jest --watch"
   },


### PR DESCRIPTION
The README has been updated to reflect that we're now using Yarn v3 and Node.js v14. The now-unused `setup` command has been removed as well.