### PR TITLE
allow any minor version of bn.js above 4.11.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-sig-util",
-  "version": "5.1.0",
+  "version": "5.0.1",
   "description": "A few useful functions for signing ethereum data",
   "keywords": [
     "ethereum",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-sig-util",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "A few useful functions for signing ethereum data",
   "keywords": [
     "ethereum",
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@ethereumjs/util": "^8.0.0",
-    "bn.js": "4.11.8",
+    "bn.js": "^4.11.8",
     "ethereum-cryptography": "^1.1.2",
     "ethjs-util": "^0.1.6",
     "tweetnacl": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -867,7 +867,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^4.28.2
     "@typescript-eslint/parser": ^4.28.2
     ajv: ^8.11.0
-    bn.js: 4.11.8
+    bn.js: ^4.11.8
     eslint: ^7.30.0
     eslint-config-prettier: ^8.3.0
     eslint-plugin-import: ^2.23.4
@@ -1696,10 +1696,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:4.11.8":
-  version: 4.11.8
-  resolution: "bn.js@npm:4.11.8"
-  checksum: 80d4709cd58a21f0be8201e9e5859fea5ef133318e9800c8454cd334625c6e1caea593ca21f9b9a085fb560fbc12fb2fb3514363f8604258db924237fd039139
+"bn.js@npm:^4.11.8":
+  version: 4.12.0
+  resolution: "bn.js@npm:4.12.0"
+  checksum: 39afb4f15f4ea537b55eaf1446c896af28ac948fdcf47171961475724d1bb65118cca49fa6e3d67706e4790955ec0e74de584e45c8f1ef89f46c812bee5b5a12
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We're going to get rid of `bn.js` with https://github.com/MetaMask/eth-sig-util/pull/273, but until then we should allow any minor version bump above `4.11.8` so that we can consolidate our bundle on on version for all instances of `v4`. Not sure why I didn't think we could do this before.