### PR TITLE
fix: return "0x00" for normalize(0)

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -111,6 +111,12 @@ describe('normalize', function () {
     expect(result).toBe(`0x${initial.toLowerCase()}`);
   });
 
+  it('should normalize 0 to a byte-pair hex string', function () {
+    const initial = 0;
+    const result = normalize(initial);
+    expect(result).toBe('0x00');
+  });
+
   it('should normalize an integer to a byte-pair hex string', function () {
     const initial = 1;
     const result = normalize(initial);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -103,16 +103,16 @@ export function recoverPublicKey(
  * @returns The normalized value.
  */
 export function normalize(input: number | string): string | undefined {
-  if (!input) {
-    return undefined;
-  }
-
   if (typeof input === 'number') {
     if (input < 0) {
       return '0x';
     }
     const buffer = toBuffer(input);
     input = bufferToHex(buffer);
+  }
+
+  if (!input) {
+    return undefined;
   }
 
   if (typeof input !== 'string') {


### PR DESCRIPTION
The `normalize` function returns `0x${number}` for all numbers except `0`, for which it returns `undefined`. This changes it to return `0x00` for `0`.