### PR TITLE
docs: Remove outdated example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A small collection of Ethereum signing functions.
 
-You can find usage examples [here](https://github.com/metamask/test-dapp)
-
 [Available on NPM](https://www.npmjs.com/package/@metamask/eth-sig-util)
 
 ## Installation


### PR DESCRIPTION
See open issues in repo.

Before being linked as example, it should:
- Work out of the box on Nodejs v18, v20
- Use `@metamask/eth-sig-util` instead of deprecated `eth-sig-util`
- Update or replace other deprecated dependencies (webpack; other ethereum-related libraries)