### PR TITLE
Fix `normalize` for empty strings

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -124,6 +124,12 @@ describe('normalize', function () {
     expect(result).toBe('0x');
   });
 
+  it('should normalize an empty string to 0x', function () {
+    const initial = '';
+    const result = normalize(initial);
+    expect(result).toBe('0x');
+  });
+
   // TODO: Add validation to disallow null.
   it('should return undefined if given null', function () {
     const initial = null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -103,7 +103,7 @@ export function recoverPublicKey(
  * @returns The normalized value.
  */
 export function normalize(input: number | string): string | undefined {
-  if (!input) {
+  if (isNullish(input)) {
     return undefined;
   }
 


### PR DESCRIPTION
Currently the `normalize` function uses a logical NOT (!) to check if the input is nullish, but this causes to return `undefined` when an empty string is passed as input.

As a fix, this PR uses the `isNullish` function instead of the logical NOT.

## Changes

* **FIXED**: `normalize` function for empty strings

## References

* See [#1441](https://github.com/MetaMask/core/pull/1441#issuecomment-1602515812)
* Related to [#1315](https://github.com/MetaMask/core/issues/1315)