### PR TITLE
chore(ci): unpin node 20.5

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,7 +14,7 @@ jobs:
       YARN_VERSION: ${{ steps.yarn-version.outputs.YARN_VERSION }}
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.5]
+        node-version: [16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -41,7 +41,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.5]
+        node-version: [16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -69,7 +69,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.5]
+        node-version: [16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -103,7 +103,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.5]
+        node-version: [16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Follow-up to:
- #332 

Node.js 20.6.1 has since been released, which addresses the reason this was originally pinned.