### PR TITLE
deps: remove ethjs-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@metamask/abi-utils": "^2.0.2",
     "@metamask/utils": "^8.1.0",
     "ethereum-cryptography": "^2.1.2",
-    "ethjs-util": "^0.1.6",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1"
   },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,12 +3,18 @@ import {
   ecrecover,
   fromRpcSig,
   fromSigned,
+  isHexString,
   toBuffer,
   ToBufferInputTypes,
   toUnsigned,
 } from '@ethereumjs/util';
-import { add0x, bytesToHex, numberToBytes } from '@metamask/utils';
-import { intToHex, isHexString, stripHexPrefix } from 'ethjs-util';
+import {
+  numberToHex,
+  remove0x,
+  add0x,
+  bytesToHex,
+  numberToBytes,
+} from '@metamask/utils';
 
 /**
  * Pads the front of the given hex string with zeroes until it reaches the
@@ -76,7 +82,7 @@ export function concatSig(v: Buffer, r: Buffer, s: Buffer): string {
   const vSig = bufferToInt(v);
   const rStr = padWithZeroes(toUnsigned(rSig).toString('hex'), 64);
   const sStr = padWithZeroes(toUnsigned(sSig).toString('hex'), 64);
-  const vStr = stripHexPrefix(intToHex(vSig));
+  const vStr = remove0x(numberToHex(vSig));
   return add0x(rStr.concat(sStr, vStr));
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,7 +916,6 @@ __metadata:
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^4.2.1
     ethereum-cryptography: ^2.1.2
-    ethjs-util: ^0.1.6
     jest: ^27.0.6
     prettier: ^2.3.2
     prettier-plugin-packagejson: ^2.2.11
@@ -2706,16 +2705,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethjs-util@npm:^0.1.6":
-  version: 0.1.6
-  resolution: "ethjs-util@npm:0.1.6"
-  dependencies:
-    is-hex-prefixed: 1.0.0
-    strip-hex-prefix: 1.0.0
-  checksum: 1f42959e78ec6f49889c49c8a98639e06f52a15966387dd39faf2930db48663d026efb7db2702dcffe7f2a99c4a0144b7ce784efdbf733f4077aae95de76d65f
-  languageName: node
-  linkType: hard
-
 "execa@npm:^5.0.0, execa@npm:^5.1.1":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
@@ -3429,13 +3418,6 @@ __metadata:
   dependencies:
     is-extglob: ^2.1.1
   checksum: d381c1319fcb69d341cc6e6c7cd588e17cd94722d9a32dbd60660b993c4fb7d0f19438674e68dfec686d09b7c73139c9166b47597f846af387450224a8101ab4
-  languageName: node
-  linkType: hard
-
-"is-hex-prefixed@npm:1.0.0":
-  version: 1.0.0
-  resolution: "is-hex-prefixed@npm:1.0.0"
-  checksum: 5ac58e6e528fb029cc43140f6eeb380fad23d0041cc23154b87f7c9a1b728bcf05909974e47248fd0b7fcc11ba33cf7e58d64804883056fabd23e2b898be41de
   languageName: node
   linkType: hard
 
@@ -5578,15 +5560,6 @@ __metadata:
   version: 2.0.0
   resolution: "strip-final-newline@npm:2.0.0"
   checksum: 69412b5e25731e1938184b5d489c32e340605bb611d6140344abc3421b7f3c6f9984b21dff296dfcf056681b82caa3bb4cc996a965ce37bcfad663e92eae9c64
-  languageName: node
-  linkType: hard
-
-"strip-hex-prefix@npm:1.0.0":
-  version: 1.0.0
-  resolution: "strip-hex-prefix@npm:1.0.0"
-  dependencies:
-    is-hex-prefixed: 1.0.0
-  checksum: 4cafe7caee1d281d3694d14920fd5d3c11adf09371cef7e2ccedd5b83efd9e9bd2219b5d6ce6e809df6e0f437dc9d30db1192116580875698aad164a6d6b285b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Legacy package. Replaced utility functions with equivalents from already used `@metamask/utils` and `@ethereums/util`.

- Resolves #329