### PR TITLE
deps: replace tweetnacl-util with @scure/base

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "@ethereumjs/util": "^8.1.0",
     "@metamask/abi-utils": "^2.0.2",
     "@metamask/utils": "^8.1.0",
+    "@scure/base": "~1.1.3",
     "ethereum-cryptography": "^2.1.2",
-    "tweetnacl": "^1.0.3",
-    "tweetnacl-util": "^0.15.1"
+    "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,6 +903,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^11.1.0
     "@metamask/eslint-config-typescript": ^11.1.0
     "@metamask/utils": ^8.1.0
+    "@scure/base": ~1.1.3
     "@types/jest": ^27.0.6
     "@types/node": ^16.18.50
     "@typescript-eslint/eslint-plugin": ^5.59.1
@@ -922,7 +923,6 @@ __metadata:
     rimraf: ^3.0.2
     ts-jest: ^27.0.3
     tweetnacl: ^1.0.3
-    tweetnacl-util: ^0.15.1
     typedoc: ^0.24.6
     typescript: ~4.8.4
   languageName: unknown
@@ -1044,7 +1044,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@scure/base@npm:^1.1.3":
+"@scure/base@npm:^1.1.3, @scure/base@npm:~1.1.3":
   version: 1.1.6
   resolution: "@scure/base@npm:1.1.6"
   checksum: d6deaae91deba99e87939af9e55d80edba302674983f32bba57f942e22b1726a83c62dc50d8f4370a5d5d35a212dda167fb169f4b0d0c297488d8604608fc3d3
@@ -5805,13 +5805,6 @@ __metadata:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 1843f4c1b2e0f975e08c4c21caa4af4f7f65a12ac1b81b3b8489366826259323feb3fc7a243123453d2d1a02314205a7634e048d4a8009921da19f99755cdc48
-  languageName: node
-  linkType: hard
-
-"tweetnacl-util@npm:^0.15.1":
-  version: 0.15.1
-  resolution: "tweetnacl-util@npm:0.15.1"
-  checksum: ae6aa8a52cdd21a95103a4cc10657d6a2040b36c7a6da7b9d3ab811c6750a2d5db77e8c36969e75fdee11f511aa2b91c552496c6e8e989b6e490e54aca2864fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- `tweetnacl-util` is no longer actively maintained
- `@scure/base` is already pulled in transitively through `ethereum-cryptography`
- Remove redundant base64 encode/decode step when decoding hex input


### Related
- #289 