### PR TITLE
Bump `@metamask/utils` from `^9.0.0` to `^11.0.1` and `@metamask/abi-utils` from `^2.0.4` to `^3.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   },
   "dependencies": {
     "@ethereumjs/util": "^8.1.0",
-    "@metamask/abi-utils": "^2.0.4",
-    "@metamask/utils": "^9.0.0",
+    "@metamask/abi-utils": "^3.0.0",
+    "@metamask/utils": "^11.0.1",
     "@scure/base": "~1.1.3",
     "ethereum-cryptography": "^2.1.2",
     "tweetnacl": "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,13 +816,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/abi-utils@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "@metamask/abi-utils@npm:2.0.4"
+"@metamask/abi-utils@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@metamask/abi-utils@npm:3.0.0"
   dependencies:
     "@metamask/superstruct": ^3.1.0
-    "@metamask/utils": ^9.0.0
-  checksum: 85b15419248ddec1ab59ec5f3e41276f7509dadd9ced871658fa3cc04805ad35ace96986416aaecd24e3630e92b0ed078328966c92383ffa9b1cc3f0f357ad6c
+    "@metamask/utils": ^11.0.1
+  checksum: 5ac03df29bbb6cb34073e84022f8c53782c46de2817abf057ad4efc841921cee5b9dba8958b22373191fbf111e81b59bbb22d715020e032e06d6a922d59e37cc
   languageName: node
   linkType: hard
 
@@ -896,13 +896,13 @@ __metadata:
   dependencies:
     "@ethereumjs/util": ^8.1.0
     "@lavamoat/allow-scripts": ^2.3.1
-    "@metamask/abi-utils": ^2.0.4
+    "@metamask/abi-utils": ^3.0.0
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/eslint-config": ^11.1.0
     "@metamask/eslint-config-jest": ^11.1.0
     "@metamask/eslint-config-nodejs": ^11.1.0
     "@metamask/eslint-config-typescript": ^11.1.0
-    "@metamask/utils": ^9.0.0
+    "@metamask/utils": ^11.0.1
     "@scure/base": ~1.1.3
     "@types/jest": ^27.0.6
     "@types/node": ~18.18.14
@@ -935,9 +935,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^9.0.0":
-  version: 9.3.0
-  resolution: "@metamask/utils@npm:9.3.0"
+"@metamask/utils@npm:^11.0.1":
+  version: 11.0.1
+  resolution: "@metamask/utils@npm:11.0.1"
   dependencies:
     "@ethereumjs/tx": ^4.2.0
     "@metamask/superstruct": ^3.1.0
@@ -948,7 +948,7 @@ __metadata:
     pony-cause: ^2.1.10
     semver: ^7.5.4
     uuid: ^9.0.1
-  checksum: f720b0f7bdd46054aa88d15a9702e1de6d7200a1ca1d4f6bc48761b039f1bbffb46ac88bc87fe79e66128c196d424f3b9ef071b3cb4b40139223786d56da35e0
+  checksum: a5072f87157f6763328767bf1ddc01deb94e13f32af58d0993e0450e7e211fb29882280a1013cbdc7752b152a662be3d9beef8129a9097dba7d465389c398b3c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This bumps `@metamask/utils` from `^9.0.0` to `^11.0.1` and `@metamask/abi-utils` from `^2.0.4` to `^3.0.0`.