### PR TITLE
Fix incorrect padding for messages smaller DEFAULT_PADDING_LENGTH

### DIFF
--- a/src/encryption.test.ts
+++ b/src/encryption.test.ts
@@ -57,6 +57,22 @@ describe('encryption', function () {
     expect(result.version).toBe('x25519-xsalsa20-poly1305');
   });
 
+  it('encryption of message which is [1..NACL_EXTRA_BYTES) smaller than DEFAULT_PADDING_LENGTH in JSON', async function () {
+    const jsonOverhead = '{"data":"","padding":""}'.length;
+    const message = '0'.repeat(2 ** 11 - jsonOverhead - 10); // DEFAULT_PADDING_LENGTH - jsonOverhead - 10; 10 < NACL_EXTRA_BYTES
+    const version = 'x25519-xsalsa20-poly1305';
+    const result = encryptSafely({
+      publicKey: bob.encryptionPublicKey,
+      data: message,
+      version,
+    });
+
+    expect(result.ciphertext).toHaveLength(5464);
+    expect(result.ephemPublicKey).toHaveLength(44);
+    expect(result.nonce).toHaveLength(32);
+    expect(result.version).toBe('x25519-xsalsa20-poly1305');
+  });
+
   // safe decryption test
   it('bob decryptSafely message that Alice encryptSafely for him', async function () {
     const version = 'x25519-xsalsa20-poly1305';

--- a/src/encryption.ts
+++ b/src/encryption.ts
@@ -130,11 +130,11 @@ export function encryptSafely({
     JSON.stringify(dataWithPadding),
     'utf-8',
   );
-  const modVal = dataLength % DEFAULT_PADDING_LENGTH;
+  const modVal = (dataLength + NACL_EXTRA_BYTES) % DEFAULT_PADDING_LENGTH;
   let padLength = 0;
   // Only pad if necessary
   if (modVal > 0) {
-    padLength = DEFAULT_PADDING_LENGTH - modVal - NACL_EXTRA_BYTES; // nacl extra bytes
+    padLength = DEFAULT_PADDING_LENGTH - modVal;
   }
   dataWithPadding.padding = '0'.repeat(padLength);
 


### PR DESCRIPTION
We encountered an issue when encrypting messages with size that is smaller than `DEFAULT_PADDING_LENGTH` by `NACL_EXTRA_BYTES`. In this scenario, the current implementation uses a negative value for padding. A test is added demonstrating such behavior.

I consider the solution to be backward-compatible and only to improve the function because it will accept a wider range of inputs regarding their JSON-encoded length.