### PR TITLE
fix!: reject ambiguous bool values in signTypedData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- **BREAKING**: Reject ambiguous `bool` values in `signTypedData` (all versions) instead of coercing them ([#PLACEHOLDER](https://github.com/MetaMask/eth-sig-util/pull/PLACEHOLDER))
+- **BREAKING**: Reject ambiguous `bool` values in `signTypedData` (all versions) instead of coercing them ([#419](https://github.com/MetaMask/eth-sig-util/pull/419))
   - `bool` fields now only accept the boolean values `true`/`false` or the exact strings `'true'`/`'false'`. Any other value (e.g. `0`, `1`, `'0'`, `''`, or an arbitrary string) now throws instead of being coerced via `Boolean(value)`.
   - This fixes a signing footgun where a `bool` field supplied as the string `'false'` was encoded and signed as `true` (every non-empty string is truthy in JavaScript), while interfaces displaying the raw value showed `'false'`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **BREAKING**: Reject ambiguous `bool` values in `signTypedData` (all versions) instead of coercing them ([#PLACEHOLDER](https://github.com/MetaMask/eth-sig-util/pull/PLACEHOLDER))
+  - `bool` fields now only accept the boolean values `true`/`false` or the exact strings `'true'`/`'false'`. Any other value (e.g. `0`, `1`, `'0'`, `''`, or an arbitrary string) now throws instead of being coerced via `Boolean(value)`.
+  - This fixes a signing footgun where a `bool` field supplied as the string `'false'` was encoded and signed as `true` (every non-empty string is truthy in JavaScript), while interfaces displaying the raw value showed `'false'`.
 
 ## [8.2.0]
 ### Added

--- a/src/__snapshots__/sign-typed-data.test.ts.snap
+++ b/src/__snapshots__/sign-typed-data.test.ts.snap
@@ -40,17 +40,9 @@ exports[`TypedDataUtils.encodeData V3 example data type "address" should encode 
 
 exports[`TypedDataUtils.encodeData V3 example data type "address" should encode "bBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" (type "string") 1`] = `"c92db6bca97089c40b3f6512400e065cf2c27db90a50ce13440d951b13ada29900000000000000000000000000000023eafa60608dacea43aa64cbe38e38e38d"`;
 
-exports[`TypedDataUtils.encodeData V3 example data type "bool" should encode "-1" (type "number") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000001"`;
-
-exports[`TypedDataUtils.encodeData V3 example data type "bool" should encode "0" (type "number") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000000"`;
-
-exports[`TypedDataUtils.encodeData V3 example data type "bool" should encode "1" (type "number") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000001"`;
-
-exports[`TypedDataUtils.encodeData V3 example data type "bool" should encode "9007199254740991" (type "number") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000001"`;
-
 exports[`TypedDataUtils.encodeData V3 example data type "bool" should encode "false" (type "boolean") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000000"`;
 
-exports[`TypedDataUtils.encodeData V3 example data type "bool" should encode "false" (type "string") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000001"`;
+exports[`TypedDataUtils.encodeData V3 example data type "bool" should encode "false" (type "string") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000000"`;
 
 exports[`TypedDataUtils.encodeData V3 example data type "bool" should encode "true" (type "boolean") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000001"`;
 
@@ -220,23 +212,15 @@ exports[`TypedDataUtils.encodeData V4 example data type "address" should encode 
 
 exports[`TypedDataUtils.encodeData V4 example data type "address" should encode array of all address example data 1`] = `"1cf487eff7ac1d95e8069104ae1f91e4ecc076c3a5c23645a8b93a413d1bc7118eb4f5f4cd3a16acaa954558d08ceb9f1a1dfd26dbf9eb2b780b871fa554bbcd"`;
 
-exports[`TypedDataUtils.encodeData V4 example data type "bool" should encode "-1" (type "number") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000001"`;
-
-exports[`TypedDataUtils.encodeData V4 example data type "bool" should encode "0" (type "number") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000000"`;
-
-exports[`TypedDataUtils.encodeData V4 example data type "bool" should encode "1" (type "number") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000001"`;
-
-exports[`TypedDataUtils.encodeData V4 example data type "bool" should encode "9007199254740991" (type "number") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000001"`;
-
 exports[`TypedDataUtils.encodeData V4 example data type "bool" should encode "false" (type "boolean") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000000"`;
 
-exports[`TypedDataUtils.encodeData V4 example data type "bool" should encode "false" (type "string") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000001"`;
+exports[`TypedDataUtils.encodeData V4 example data type "bool" should encode "false" (type "string") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000000"`;
 
 exports[`TypedDataUtils.encodeData V4 example data type "bool" should encode "true" (type "boolean") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000001"`;
 
 exports[`TypedDataUtils.encodeData V4 example data type "bool" should encode "true" (type "string") 1`] = `"83478c46da931c2f6871fdb6febd69a27b0ebc8c91f3e2cf580c3bd8777690060000000000000000000000000000000000000000000000000000000000000001"`;
 
-exports[`TypedDataUtils.encodeData V4 example data type "bool" should encode array of all bool example data 1`] = `"f2b07a6e9f364e1284b89fa1c7ea1c89520fd1eb16169108f5c86e3ff94a80ab67ab9e81b4411ccf66289482fc98cdf324bcadcc0e113aa64abf6c115dda652d"`;
+exports[`TypedDataUtils.encodeData V4 example data type "bool" should encode array of all bool example data 1`] = `"f2b07a6e9f364e1284b89fa1c7ea1c89520fd1eb16169108f5c86e3ff94a80abdfe58d84d79c0cbbb7049c2ae941fda618361becdde035bdcf8dcc92ce5d21a1"`;
 
 exports[`TypedDataUtils.encodeData V4 example data type "bytes" should encode "0x" (type "string") 1`] = `"fe4e90aeb2dead25fb44e8b67b2f9cdb3cabea1f7555b81fcc61f7103acf5d50c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"`;
 
@@ -420,17 +404,9 @@ exports[`TypedDataUtils.hashStruct V3 example data type "address" should hash "9
 
 exports[`TypedDataUtils.hashStruct V3 example data type "address" should hash "bBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" (type "string") 1`] = `"4d9b02d96f7647b8d3acfafc97b2faa65ef7b442ea647f8c8f6f606d4d794d34"`;
 
-exports[`TypedDataUtils.hashStruct V3 example data type "bool" should hash "-1" (type "number") 1`] = `"df410941012cfe7070ec9abfdb367531856dda97faaa5134e46c313058e8415e"`;
-
-exports[`TypedDataUtils.hashStruct V3 example data type "bool" should hash "0" (type "number") 1`] = `"8015e06ae558f4ef85aa3a10a88e0530c81d4c6437ea005773d0ae01fa87e98f"`;
-
-exports[`TypedDataUtils.hashStruct V3 example data type "bool" should hash "1" (type "number") 1`] = `"df410941012cfe7070ec9abfdb367531856dda97faaa5134e46c313058e8415e"`;
-
-exports[`TypedDataUtils.hashStruct V3 example data type "bool" should hash "9007199254740991" (type "number") 1`] = `"df410941012cfe7070ec9abfdb367531856dda97faaa5134e46c313058e8415e"`;
-
 exports[`TypedDataUtils.hashStruct V3 example data type "bool" should hash "false" (type "boolean") 1`] = `"8015e06ae558f4ef85aa3a10a88e0530c81d4c6437ea005773d0ae01fa87e98f"`;
 
-exports[`TypedDataUtils.hashStruct V3 example data type "bool" should hash "false" (type "string") 1`] = `"df410941012cfe7070ec9abfdb367531856dda97faaa5134e46c313058e8415e"`;
+exports[`TypedDataUtils.hashStruct V3 example data type "bool" should hash "false" (type "string") 1`] = `"8015e06ae558f4ef85aa3a10a88e0530c81d4c6437ea005773d0ae01fa87e98f"`;
 
 exports[`TypedDataUtils.hashStruct V3 example data type "bool" should hash "true" (type "boolean") 1`] = `"df410941012cfe7070ec9abfdb367531856dda97faaa5134e46c313058e8415e"`;
 
@@ -600,23 +576,15 @@ exports[`TypedDataUtils.hashStruct V4 example data type "address" should hash "b
 
 exports[`TypedDataUtils.hashStruct V4 example data type "address" should hash array of all address example data 1`] = `"d714a2e5e9f4db8583cd86e447c95fdbb86e6fe7a8fdc576197c3f0805d1a693"`;
 
-exports[`TypedDataUtils.hashStruct V4 example data type "bool" should hash "-1" (type "number") 1`] = `"df410941012cfe7070ec9abfdb367531856dda97faaa5134e46c313058e8415e"`;
-
-exports[`TypedDataUtils.hashStruct V4 example data type "bool" should hash "0" (type "number") 1`] = `"8015e06ae558f4ef85aa3a10a88e0530c81d4c6437ea005773d0ae01fa87e98f"`;
-
-exports[`TypedDataUtils.hashStruct V4 example data type "bool" should hash "1" (type "number") 1`] = `"df410941012cfe7070ec9abfdb367531856dda97faaa5134e46c313058e8415e"`;
-
-exports[`TypedDataUtils.hashStruct V4 example data type "bool" should hash "9007199254740991" (type "number") 1`] = `"df410941012cfe7070ec9abfdb367531856dda97faaa5134e46c313058e8415e"`;
-
 exports[`TypedDataUtils.hashStruct V4 example data type "bool" should hash "false" (type "boolean") 1`] = `"8015e06ae558f4ef85aa3a10a88e0530c81d4c6437ea005773d0ae01fa87e98f"`;
 
-exports[`TypedDataUtils.hashStruct V4 example data type "bool" should hash "false" (type "string") 1`] = `"df410941012cfe7070ec9abfdb367531856dda97faaa5134e46c313058e8415e"`;
+exports[`TypedDataUtils.hashStruct V4 example data type "bool" should hash "false" (type "string") 1`] = `"8015e06ae558f4ef85aa3a10a88e0530c81d4c6437ea005773d0ae01fa87e98f"`;
 
 exports[`TypedDataUtils.hashStruct V4 example data type "bool" should hash "true" (type "boolean") 1`] = `"df410941012cfe7070ec9abfdb367531856dda97faaa5134e46c313058e8415e"`;
 
 exports[`TypedDataUtils.hashStruct V4 example data type "bool" should hash "true" (type "string") 1`] = `"df410941012cfe7070ec9abfdb367531856dda97faaa5134e46c313058e8415e"`;
 
-exports[`TypedDataUtils.hashStruct V4 example data type "bool" should hash array of all bool example data 1`] = `"6f00436587cd0a7f731ee48fd94e198edb2139db837718bb8fc49016083f3e57"`;
+exports[`TypedDataUtils.hashStruct V4 example data type "bool" should hash array of all bool example data 1`] = `"f0293441c16b32ae4358b655530e7c7cc1b31769e075028fdd5f6c3767fd675f"`;
 
 exports[`TypedDataUtils.hashStruct V4 example data type "bytes" should hash "0x" (type "string") 1`] = `"84b16210669f991d43a594d6851da4c5d1b77604564452ba4fff8d8e30b215b3"`;
 
@@ -792,23 +760,15 @@ exports[`signTypedData V1 example data type "address" should sign "0xbBbBBBBbbBB
 
 exports[`signTypedData V1 example data type "address" should sign array of all address example data 1`] = `"0x3f19e48278818473854f97fb5f5047770ee37fc5c788fb4c7bee2f895f6ce5944134bed59448376d8808c1d929c3d5c6079817489f8f476f740507a60b0bc2521c"`;
 
-exports[`signTypedData V1 example data type "bool" should sign "-1" (type "number") 1`] = `"0xcd5eb57c6a6bdda70a472ce41f441a1a5b293d8bffb83772e2f26cba45cc3d651cbd1b5fc7b9040f96f2e1a4eee3b75017602846d880a957666583802dd82bc81b"`;
-
-exports[`signTypedData V1 example data type "bool" should sign "0" (type "number") 1`] = `"0x1ea2763958f20cdef74f16491237aa12f39787717574e9251034547edbdbb4c86486b24813846ee8ea6dd68654f78f5239e94e8d228069654fb0566819bdaa291b"`;
-
-exports[`signTypedData V1 example data type "bool" should sign "1" (type "number") 1`] = `"0xcd5eb57c6a6bdda70a472ce41f441a1a5b293d8bffb83772e2f26cba45cc3d651cbd1b5fc7b9040f96f2e1a4eee3b75017602846d880a957666583802dd82bc81b"`;
-
-exports[`signTypedData V1 example data type "bool" should sign "9007199254740991" (type "number") 1`] = `"0xcd5eb57c6a6bdda70a472ce41f441a1a5b293d8bffb83772e2f26cba45cc3d651cbd1b5fc7b9040f96f2e1a4eee3b75017602846d880a957666583802dd82bc81b"`;
-
 exports[`signTypedData V1 example data type "bool" should sign "false" (type "boolean") 1`] = `"0x1ea2763958f20cdef74f16491237aa12f39787717574e9251034547edbdbb4c86486b24813846ee8ea6dd68654f78f5239e94e8d228069654fb0566819bdaa291b"`;
 
-exports[`signTypedData V1 example data type "bool" should sign "false" (type "string") 1`] = `"0xcd5eb57c6a6bdda70a472ce41f441a1a5b293d8bffb83772e2f26cba45cc3d651cbd1b5fc7b9040f96f2e1a4eee3b75017602846d880a957666583802dd82bc81b"`;
+exports[`signTypedData V1 example data type "bool" should sign "false" (type "string") 1`] = `"0x1ea2763958f20cdef74f16491237aa12f39787717574e9251034547edbdbb4c86486b24813846ee8ea6dd68654f78f5239e94e8d228069654fb0566819bdaa291b"`;
 
 exports[`signTypedData V1 example data type "bool" should sign "true" (type "boolean") 1`] = `"0xcd5eb57c6a6bdda70a472ce41f441a1a5b293d8bffb83772e2f26cba45cc3d651cbd1b5fc7b9040f96f2e1a4eee3b75017602846d880a957666583802dd82bc81b"`;
 
 exports[`signTypedData V1 example data type "bool" should sign "true" (type "string") 1`] = `"0xcd5eb57c6a6bdda70a472ce41f441a1a5b293d8bffb83772e2f26cba45cc3d651cbd1b5fc7b9040f96f2e1a4eee3b75017602846d880a957666583802dd82bc81b"`;
 
-exports[`signTypedData V1 example data type "bool" should sign array of all bool example data 1`] = `"0x6bd0c6dd4d2b7f822eaf1b19708367f0962e78239224fb65573ed53b847b741a6ea2f7397c1578902b764f16e371201f011d6e8102473a3cf6edd1c2467ebd531b"`;
+exports[`signTypedData V1 example data type "bool" should sign array of all bool example data 1`] = `"0x015fbc842635668209578e77386530f941a8aa5e55356029f2d717c57d8644595df6545bc02a93e1a2570ee8a8b17fffe0a605dab156cc65317909c8500f83011c"`;
 
 exports[`signTypedData V1 example data type "bytes" should sign "0x10" (type "string") 1`] = `"0xa110741a43ecb6b47993f5b821d7352b11b3c683995ac0f75818ee8aaec46f711008c6396607b1b48d137dfff943c1e2d3f75adc8bb37648841a49b4c164913e1c"`;
 
@@ -952,17 +912,9 @@ exports[`signTypedData V3 example data type "address" should sign "9007199254740
 
 exports[`signTypedData V3 example data type "address" should sign "bBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" (type "string") 1`] = `"0x47ad9b795affe960475274f8b067225cff2451eada53b0ccf9bebd4336674b4b35b9ac6bad764f197435c7d53b6992a6d5f835796346a6ee4fd2313f8dd5b8991b"`;
 
-exports[`signTypedData V3 example data type "bool" should sign "-1" (type "number") 1`] = `"0x5266f7fdc7b8d6552656609f7160760f323a4b37ba80e41b33fdb5637349538c123e338354fd3c0fa0741725c3a273a3857d9a2f490b7ebd612b83d10b2246a11b"`;
-
-exports[`signTypedData V3 example data type "bool" should sign "0" (type "number") 1`] = `"0xf61ac8da1b7c663c7a7d16d1fefc75ffa739cd5a7af7b165405df3f616f899fa205e73f6f885b7fb6a4f0a5ec14c715c8642d4f59cb88abd361c8a1590cd70071b"`;
-
-exports[`signTypedData V3 example data type "bool" should sign "1" (type "number") 1`] = `"0x5266f7fdc7b8d6552656609f7160760f323a4b37ba80e41b33fdb5637349538c123e338354fd3c0fa0741725c3a273a3857d9a2f490b7ebd612b83d10b2246a11b"`;
-
-exports[`signTypedData V3 example data type "bool" should sign "9007199254740991" (type "number") 1`] = `"0x5266f7fdc7b8d6552656609f7160760f323a4b37ba80e41b33fdb5637349538c123e338354fd3c0fa0741725c3a273a3857d9a2f490b7ebd612b83d10b2246a11b"`;
-
 exports[`signTypedData V3 example data type "bool" should sign "false" (type "boolean") 1`] = `"0xf61ac8da1b7c663c7a7d16d1fefc75ffa739cd5a7af7b165405df3f616f899fa205e73f6f885b7fb6a4f0a5ec14c715c8642d4f59cb88abd361c8a1590cd70071b"`;
 
-exports[`signTypedData V3 example data type "bool" should sign "false" (type "string") 1`] = `"0x5266f7fdc7b8d6552656609f7160760f323a4b37ba80e41b33fdb5637349538c123e338354fd3c0fa0741725c3a273a3857d9a2f490b7ebd612b83d10b2246a11b"`;
+exports[`signTypedData V3 example data type "bool" should sign "false" (type "string") 1`] = `"0xf61ac8da1b7c663c7a7d16d1fefc75ffa739cd5a7af7b165405df3f616f899fa205e73f6f885b7fb6a4f0a5ec14c715c8642d4f59cb88abd361c8a1590cd70071b"`;
 
 exports[`signTypedData V3 example data type "bool" should sign "true" (type "boolean") 1`] = `"0x5266f7fdc7b8d6552656609f7160760f323a4b37ba80e41b33fdb5637349538c123e338354fd3c0fa0741725c3a273a3857d9a2f490b7ebd612b83d10b2246a11b"`;
 
@@ -1140,23 +1092,15 @@ exports[`signTypedData V4 example data type "address" should sign "bBbBBBBbbBBBb
 
 exports[`signTypedData V4 example data type "address" should sign array of all address example data 1`] = `"0x4a47328b668266b3bdaa67d9c1ac201a4a2245ed185f9b81adb4acb6eb1231fe58e08ef8dd8ed85b4a264219d297e8275b761216688c8ed9bb7b367e9b99435b1c"`;
 
-exports[`signTypedData V4 example data type "bool" should sign "-1" (type "number") 1`] = `"0x5266f7fdc7b8d6552656609f7160760f323a4b37ba80e41b33fdb5637349538c123e338354fd3c0fa0741725c3a273a3857d9a2f490b7ebd612b83d10b2246a11b"`;
-
-exports[`signTypedData V4 example data type "bool" should sign "0" (type "number") 1`] = `"0xf61ac8da1b7c663c7a7d16d1fefc75ffa739cd5a7af7b165405df3f616f899fa205e73f6f885b7fb6a4f0a5ec14c715c8642d4f59cb88abd361c8a1590cd70071b"`;
-
-exports[`signTypedData V4 example data type "bool" should sign "1" (type "number") 1`] = `"0x5266f7fdc7b8d6552656609f7160760f323a4b37ba80e41b33fdb5637349538c123e338354fd3c0fa0741725c3a273a3857d9a2f490b7ebd612b83d10b2246a11b"`;
-
-exports[`signTypedData V4 example data type "bool" should sign "9007199254740991" (type "number") 1`] = `"0x5266f7fdc7b8d6552656609f7160760f323a4b37ba80e41b33fdb5637349538c123e338354fd3c0fa0741725c3a273a3857d9a2f490b7ebd612b83d10b2246a11b"`;
-
 exports[`signTypedData V4 example data type "bool" should sign "false" (type "boolean") 1`] = `"0xf61ac8da1b7c663c7a7d16d1fefc75ffa739cd5a7af7b165405df3f616f899fa205e73f6f885b7fb6a4f0a5ec14c715c8642d4f59cb88abd361c8a1590cd70071b"`;
 
-exports[`signTypedData V4 example data type "bool" should sign "false" (type "string") 1`] = `"0x5266f7fdc7b8d6552656609f7160760f323a4b37ba80e41b33fdb5637349538c123e338354fd3c0fa0741725c3a273a3857d9a2f490b7ebd612b83d10b2246a11b"`;
+exports[`signTypedData V4 example data type "bool" should sign "false" (type "string") 1`] = `"0xf61ac8da1b7c663c7a7d16d1fefc75ffa739cd5a7af7b165405df3f616f899fa205e73f6f885b7fb6a4f0a5ec14c715c8642d4f59cb88abd361c8a1590cd70071b"`;
 
 exports[`signTypedData V4 example data type "bool" should sign "true" (type "boolean") 1`] = `"0x5266f7fdc7b8d6552656609f7160760f323a4b37ba80e41b33fdb5637349538c123e338354fd3c0fa0741725c3a273a3857d9a2f490b7ebd612b83d10b2246a11b"`;
 
 exports[`signTypedData V4 example data type "bool" should sign "true" (type "string") 1`] = `"0x5266f7fdc7b8d6552656609f7160760f323a4b37ba80e41b33fdb5637349538c123e338354fd3c0fa0741725c3a273a3857d9a2f490b7ebd612b83d10b2246a11b"`;
 
-exports[`signTypedData V4 example data type "bool" should sign array of all bool example data 1`] = `"0x19a45e21d1ab3816c208f5342e17004adbf0eb8732386c2b7631a12445e0c838387b0d5a7774339119351a3dc55ff5fb749c40d375b3492b04919ed205d70fee1c"`;
+exports[`signTypedData V4 example data type "bool" should sign array of all bool example data 1`] = `"0x6d51666200732ed7ce5e8840f2163cd94273d44b9075e552ed72efe38300ffbe1baca486c24a8d2d3383b5029cff4a5a85db8d4ba54d289d20d1e06d930cea301c"`;
 
 exports[`signTypedData V4 example data type "bytes" should sign "0x" (type "string") 1`] = `"0xfd9fdcd8d428bdcf00d760e9f984f4c8ec1703fc5503e5f02bf00292d6ce65e71175fe5666983a14ca41dba4b2b81c9b384bae97d8ec3ba84c7de4d4b79ab72d1c"`;
 
@@ -1338,17 +1282,9 @@ exports[`typedSignatureHash type "address" should hash "0xbBbBBBBbbBBBbbbBbbBbbb
 
 exports[`typedSignatureHash type "address" should hash "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbBbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" (type "string") 1`] = `"0x04c21f11808f1da08fcc268b752f1b27ff3398234a08c4e4ec3350518c03555d"`;
 
-exports[`typedSignatureHash type "bool" should hash "-1" (type "number") 1`] = `"0x4401c8323e5bef2e92610abb1fdec4b8d6672a233a3ab50c621a62193e7c998d"`;
-
-exports[`typedSignatureHash type "bool" should hash "0" (type "number") 1`] = `"0x5611bafe7fef082941c84a60b14c9c9bc65e75b6c3a8bdde354ea7c19224133c"`;
-
-exports[`typedSignatureHash type "bool" should hash "1" (type "number") 1`] = `"0x4401c8323e5bef2e92610abb1fdec4b8d6672a233a3ab50c621a62193e7c998d"`;
-
-exports[`typedSignatureHash type "bool" should hash "9007199254740991" (type "number") 1`] = `"0x4401c8323e5bef2e92610abb1fdec4b8d6672a233a3ab50c621a62193e7c998d"`;
-
 exports[`typedSignatureHash type "bool" should hash "false" (type "boolean") 1`] = `"0x5611bafe7fef082941c84a60b14c9c9bc65e75b6c3a8bdde354ea7c19224133c"`;
 
-exports[`typedSignatureHash type "bool" should hash "false" (type "string") 1`] = `"0x4401c8323e5bef2e92610abb1fdec4b8d6672a233a3ab50c621a62193e7c998d"`;
+exports[`typedSignatureHash type "bool" should hash "false" (type "string") 1`] = `"0x5611bafe7fef082941c84a60b14c9c9bc65e75b6c3a8bdde354ea7c19224133c"`;
 
 exports[`typedSignatureHash type "bool" should hash "true" (type "boolean") 1`] = `"0x4401c8323e5bef2e92610abb1fdec4b8d6672a233a3ab50c621a62193e7c998d"`;
 

--- a/src/sign-typed-data.test.ts
+++ b/src/sign-typed-data.test.ts
@@ -277,7 +277,7 @@ const encodeDataExamples = {
     MAX_SAFE_INTEGER_AS_HEX,
     MAX_SAFE_INTEGER_PLUS_ONE_CHAR_AS_HEX,
   ],
-  bool: [true, false, 'true', 'false', 0, 1, -1, Number.MAX_SAFE_INTEGER],
+  bool: [true, false, 'true', 'false'],
   bytes1: [
     '0x10', // even
     '0x101', // odd
@@ -319,6 +319,28 @@ const encodeDataErrorExamples = {
       input: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB0',
       errorMessage:
         'Unable to encode value: Invalid address value. Expected address to be 20 bytes long, but received 21 bytes.',
+    },
+  ],
+  bool: [
+    {
+      input: 0,
+      errorMessage:
+        'Unable to encode value: Invalid bool. Expected a boolean or the string "true" or "false", but received "0".',
+    },
+    {
+      input: 1,
+      errorMessage:
+        'Unable to encode value: Invalid bool. Expected a boolean or the string "true" or "false", but received "1".',
+    },
+    {
+      input: -1,
+      errorMessage:
+        'Unable to encode value: Invalid bool. Expected a boolean or the string "true" or "false", but received "-1".',
+    },
+    {
+      input: Number.MAX_SAFE_INTEGER,
+      errorMessage:
+        'Unable to encode value: Invalid bool. Expected a boolean or the string "true" or "false", but received "9007199254740991".',
     },
   ],
   int8: [
@@ -4298,7 +4320,7 @@ const signTypedDataV1Examples = {
     '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbBbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
     '0x0',
   ],
-  bool: [true, false, 'true', 'false', 0, 1, -1, Number.MAX_SAFE_INTEGER],
+  bool: [true, false, 'true', 'false'],
   bytes1: [
     '0x10',
     10,
@@ -4341,6 +4363,28 @@ const signTypedDataV1ErrorExamples = {
       // V1: Does not accept numbers as strings (arguably correctly).
       input: 10,
       errorMessage: 'Value must be a string.',
+    },
+  ],
+  bool: [
+    {
+      input: 0,
+      errorMessage:
+        'Unable to encode value: Invalid bool. Expected a boolean or the string "true" or "false", but received "0".',
+    },
+    {
+      input: 1,
+      errorMessage:
+        'Unable to encode value: Invalid bool. Expected a boolean or the string "true" or "false", but received "1".',
+    },
+    {
+      input: -1,
+      errorMessage:
+        'Unable to encode value: Invalid bool. Expected a boolean or the string "true" or "false", but received "-1".',
+    },
+    {
+      input: Number.MAX_SAFE_INTEGER,
+      errorMessage:
+        'Unable to encode value: Invalid bool. Expected a boolean or the string "true" or "false", but received "9007199254740991".',
     },
   ],
   address: [
@@ -4388,6 +4432,49 @@ const allSignTypedDataV1ExampleTypes = [
     ),
   ),
 ];
+
+describe('bool encoding', function () {
+  const encodeBool = (
+    value: unknown,
+    version: SignTypedDataVersion.V3 | SignTypedDataVersion.V4,
+  ) =>
+    TypedDataUtils.encodeData(
+      'Message',
+      { data: value },
+      { Message: [{ name: 'data', type: 'bool' }] },
+      version,
+    ).toString('hex');
+
+  const versions = [SignTypedDataVersion.V3, SignTypedDataVersion.V4] as const;
+
+  for (const version of versions) {
+    describe(`${version}`, function () {
+      it('encodes the string "false" the same as the boolean false', function () {
+        expect(encodeBool('false', version)).toBe(encodeBool(false, version));
+      });
+
+      it('encodes the string "false" differently from the boolean true', function () {
+        expect(encodeBool('false', version)).not.toBe(
+          encodeBool(true, version),
+        );
+      });
+
+      it('encodes the string "true" the same as the boolean true', function () {
+        expect(encodeBool('true', version)).toBe(encodeBool(true, version));
+      });
+
+      for (const value of [0, 1, -1, '0', '1', '', 'no', 'False', 'TRUE']) {
+        it(`rejects the ambiguous value "${value}" (type "${typeof value}")`, function () {
+          expect(() => encodeBool(value, version)).toThrow(
+            `Unable to encode value: Invalid bool. Expected a boolean or the string "true" or "false", but received "${String(
+              value,
+            )}".`,
+          );
+        });
+      }
+    });
+  }
+});
 
 describe('typedSignatureHash', function () {
   for (const type of allSignTypedDataV1ExampleTypes) {

--- a/src/sign-typed-data.ts
+++ b/src/sign-typed-data.ts
@@ -181,6 +181,40 @@ function parseNumber(type: string, value: string | number | bigint) {
 }
 
 /**
+ * Normalize a value for the Solidity `bool` type. Only real booleans and the
+ * exact strings `'true'` and `'false'` are accepted; anything else is rejected.
+ *
+ * The previous `Boolean(value)` implementation was a signing footgun: every
+ * non-empty string is truthy, so a `bool` field supplied as the string
+ * `'false'` was signed as `true` while UIs stringifying the raw value displayed
+ * `'false'`. Rejecting ambiguous input keeps the signed value consistent with
+ * what was requested.
+ *
+ * @param value - The value to normalize.
+ * @returns The normalized boolean.
+ * @throws If the value is not a boolean or the string `'true'` or `'false'`.
+ */
+function normalizeBool(value: unknown): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (value === 'true') {
+    return true;
+  }
+
+  if (value === 'false') {
+    return false;
+  }
+
+  throw new Error(
+    `Unable to encode value: Invalid bool. Expected a boolean or the string "true" or "false", but received "${String(
+      value,
+    )}".`,
+  );
+}
+
+/**
  * Parse an address string to a `Uint8Array`. The behaviour of this is quite
  * strange, in that it does not parse the address as hexadecimal string, nor as
  * UTF-8. It does some weird stuff with the string and char codes, and then
@@ -271,7 +305,7 @@ function encodeField(
   }
 
   if (type === 'bool') {
-    return ['bool', Boolean(value)];
+    return ['bool', normalizeBool(value)];
   }
 
   if (type === 'bytes') {
@@ -615,7 +649,7 @@ function normalizeValue(type: string, value: unknown): any {
   }
 
   if (type === 'bool') {
-    return Boolean(value);
+    return normalizeBool(value);
   }
 
   if (type.startsWith('bytes') && type !== 'bytes') {


### PR DESCRIPTION
## Explanation

`signTypedData` encoded `bool` fields with `Boolean(value)` in both the V3/V4 encoder (`encodeField`) and the V1 path (`normalizeValue`). Because every non-empty string is truthy in JavaScript, a `bool` field supplied as the **string** `"false"` was encoded and signed as **`true`**, while consumers that stringify the raw value (e.g. wallet confirmation UIs using `String(value)`) displayed `"false"`.

This is a signing-integrity footgun: the value a user is shown can silently disagree with the value that is actually hashed and signed, allowing a malicious dApp to obtain a signature authorizing the opposite boolean from what was displayed.

## Fix

`bool` values are now normalized through a shared `normalizeBool` helper used by both encoding paths:

- Accepts the booleans `true` / `false`.
- Accepts the exact strings `'true'` / `'false'` (normalized correctly, so `'false'` → `false`).
- Rejects anything else (`0`, `1`, `-1`, `'0'`, `''`, arbitrary strings, etc.) by throwing, rather than silently coercing.

This mirrors the input-validation hardening pattern already established in #410 (EIP-7702 validation).

## Behavior change

`"false"` (string) now encodes/signs as `false` instead of `true` — see the updated snapshots. Values that previously coerced via `Boolean(value)` (e.g. `0`, `1`, `-1`, large numbers) now throw with a descriptive error.

## References

- Fixes: CONF-1807

## Changelog

`CHANGELOG entry: **BREAKING**: bool fields in signTypedData now only accept the booleans true/false or the strings 'true'/'false'; other values are rejected instead of being coerced (previously a bool passed as the string "false" was signed as true).`

## Test Plan

- `yarn test` — full suite passes (1391 tests, coverage thresholds met).
- Added dedicated `bool encoding` tests asserting:
  - `'false'` encodes identically to `false` and differently from `true` (V3/V4).
  - `'true'` encodes identically to `true`.
  - ambiguous values (`0`, `1`, `-1`, `'0'`, `'1'`, `''`, `'no'`, `'False'`, `'TRUE'`) throw.
- Moved previously-coerced fixture values into the error-example sets for V3/V4 and V1; regenerated snapshots.
- `yarn lint` — clean.
- `yarn auto-changelog validate` — passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes EIP-712 signing semantics for bool inputs (breaking for callers relying on coercion) and fixes a security-relevant mismatch where string `'false'` was signed as true.
> 
> **Overview**
> This PR **breaks** prior coercion behavior for EIP-712 `bool` fields across **V1, V3, and V4** `signTypedData` encoding.
> 
> Instead of `Boolean(value)`, bools go through a shared **`normalizeBool`** helper that only accepts `true`/`false` or the exact strings `'true'`/`'false'`. Anything else (numbers like `0`/`1`, `'0'`, empty strings, case variants, etc.) **throws** with a clear error rather than being silently coerced.
> 
> The important behavioral fix: the string **`'false'`** now encodes and signs as **`false`** (it previously signed as **`true`** because non-empty strings are truthy in JavaScript), closing a display-vs-signed-value mismatch that could mislead users at confirmation time.
> 
> Tests drop numeric bool fixtures from happy paths, add error cases and dedicated **`bool encoding`** coverage, and snapshots are updated for the new hashes/signatures. **CHANGELOG** documents the breaking change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6390445d75bf1ac451fb39f94577cbc6ffa8982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->