### PR TITLE
revert: un-release 9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **BREAKING**: Drop support for Node.js versions 18 and 20 ([#422](https://github.com/MetaMask/eth-sig-util/pull/422))
   - The minimum supported Node.js version is now 22.
-
-## [9.0.0]
-### Changed
 - **BREAKING**: Reject ambiguous `bool` values in `signTypedData` (all versions) instead of coercing them ([#419](https://github.com/MetaMask/eth-sig-util/pull/419))
   - `bool` fields now only accept the boolean values `true`/`false` or the exact strings `'true'`/`'false'`. Any other value (e.g. `0`, `1`, `'0'`, `''`, or an arbitrary string) now throws instead of being coerced via `Boolean(value)`.
   - This fixes a signing footgun where a `bool` field supplied as the string `'false'` was encoded and signed as `true` (every non-empty string is truthy in JavaScript), while interfaces displaying the raw value showed `'false'`.
@@ -185,8 +182,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix package metadata ([#81](https://github.com/MetaMask/eth-sig-util/pull/81)
 - Switch from Node.js v8 to Node.js v10 ([#76](https://github.com/MetaMask/eth-sig-util/pull/77) and [#80](https://github.com/MetaMask/eth-sig-util/pull/80))
 
-[Unreleased]: https://github.com/MetaMask/eth-sig-util/compare/v9.0.0...HEAD
-[9.0.0]: https://github.com/MetaMask/eth-sig-util/compare/v8.2.0...v9.0.0
+[Unreleased]: https://github.com/MetaMask/eth-sig-util/compare/v8.2.0...HEAD
 [8.2.0]: https://github.com/MetaMask/eth-sig-util/compare/v8.1.2...v8.2.0
 [8.1.2]: https://github.com/MetaMask/eth-sig-util/compare/v8.1.1...v8.1.2
 [8.1.1]: https://github.com/MetaMask/eth-sig-util/compare/v8.1.0...v8.1.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-sig-util",
-  "version": "9.0.0",
+  "version": "8.2.0",
   "description": "A few useful functions for signing ethereum data",
   "keywords": [
     "ethereum",


### PR DESCRIPTION
## Explanation

The `9.0.0` release ([#420](https://github.com/MetaMask/eth-sig-util/pull/420)) was tagged but **never published to npm** — the team decided to migrate publishing to OIDC trusted publishing ([#421](https://github.com/MetaMask/eth-sig-util/pull/421)) before cutting the release. This PR un-releases `9.0.0` so it can be re-cut cleanly on top of the OIDC migration.

## Changes

- **`package.json`**: `9.0.0` → `8.2.0`.
- **`CHANGELOG.md`**:
  - Remove the `## [9.0.0]` section heading and fold its entries back under `## [Unreleased]`:
    - **BREAKING**: Reject ambiguous `bool` values in `signTypedData` ([#419](https://github.com/MetaMask/eth-sig-util/pull/419))
    - Add additional validation to EIP7702 methods ([#410](https://github.com/MetaMask/eth-sig-util/pull/410))
  - Reset the `[Unreleased]` compare link to `v8.2.0...HEAD` and drop the `[9.0.0]` link.

The Node.js 18/20 drop entry ([#422](https://github.com/MetaMask/eth-sig-util/pull/422)), which was added after `9.0.0` was cut, is preserved under `[Unreleased]`.

## Follow-ups (not in this PR)

- The existing `v9.0.0` **git tag** (`646b724`) will be deleted separately before the new `release/9.0.0` PR (npm was never published, so nothing to unpublish).
- After this merges, a fresh `release/9.0.0` PR will be created via the standard release workflow.

## References

- Reverts the release portion of #420
- Depends on OIDC migration #421 (merged)
