### PR TITLE
Release 9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [9.0.0]
 ### Changed
 - **BREAKING**: Drop support for Node.js versions 18 and 20 ([#422](https://github.com/MetaMask/eth-sig-util/pull/422))
   - The minimum supported Node.js version is now 22.
@@ -182,7 +184,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix package metadata ([#81](https://github.com/MetaMask/eth-sig-util/pull/81)
 - Switch from Node.js v8 to Node.js v10 ([#76](https://github.com/MetaMask/eth-sig-util/pull/77) and [#80](https://github.com/MetaMask/eth-sig-util/pull/80))
 
-[Unreleased]: https://github.com/MetaMask/eth-sig-util/compare/v8.2.0...HEAD
+[Unreleased]: https://github.com/MetaMask/eth-sig-util/compare/v9.0.0...HEAD
+[9.0.0]: https://github.com/MetaMask/eth-sig-util/compare/v8.2.0...v9.0.0
 [8.2.0]: https://github.com/MetaMask/eth-sig-util/compare/v8.1.2...v8.2.0
 [8.1.2]: https://github.com/MetaMask/eth-sig-util/compare/v8.1.1...v8.1.2
 [8.1.1]: https://github.com/MetaMask/eth-sig-util/compare/v8.1.0...v8.1.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-sig-util",
-  "version": "8.2.0",
+  "version": "9.0.0",
   "description": "A few useful functions for signing ethereum data",
   "keywords": [
     "ethereum",


### PR DESCRIPTION
## Explanation

Release `9.0.0`. This is the re-cut of the `9.0.0` release: the original ([#420](https://github.com/MetaMask/eth-sig-util/pull/420)) was tagged but never published to npm, and was reverted in [#423](https://github.com/MetaMask/eth-sig-util/pull/423) so the release could be re-created on top of the OIDC trusted-publishing migration ([#421](https://github.com/MetaMask/eth-sig-util/pull/421)). This release will publish via OIDC.

## Changes

- **`package.json`**: `8.2.0` → `9.0.0`.
- **`CHANGELOG.md`**: move the `[Unreleased]` entries into a new `## [9.0.0]` section and add the compare links.

### Included in 9.0.0

- **BREAKING**: Drop support for Node.js versions 18 and 20 ([#422](https://github.com/MetaMask/eth-sig-util/pull/422)) — minimum supported Node.js is now 22.
- **BREAKING**: Reject ambiguous `bool` values in `signTypedData` instead of coercing them ([#419](https://github.com/MetaMask/eth-sig-util/pull/419)).
- Add additional validation to EIP7702 methods ([#410](https://github.com/MetaMask/eth-sig-util/pull/410)).

## Checklist

- [x] `yarn auto-changelog validate --rc` passes
- [x] `yarn lint` passes
- [x] `yarn build` passes
- [x] `yarn test` passes (2782 tests)

## Notes

- **First publish over OIDC** — trusted publishing must be enabled for `@metamask/eth-sig-util` before the `publish-npm` job runs; delete `NPM_TOKEN` after the first successful OIDC publish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This PR only changes version and changelog metadata; runtime risk comes from the breaking signing and Node requirements documented for 9.0.0, not from new code in the diff.
> 
> **Overview**
> Cuts **9.0.0** by bumping `package.json` from `8.2.0` to `9.0.0` and moving the former `[Unreleased]` notes into a new **`## [9.0.0]`** section, with updated Keep a Changelog compare links (`[Unreleased]` now tracks `v9.0.0...HEAD`).
> 
> The release notes captured in the changelog (already merged elsewhere) highlight two **breaking** consumer changes: minimum **Node.js 22** (18/20 dropped), and **`signTypedData` `bool` fields** that no longer coerce ambiguous values—only `true`/`false` or `'true'`/`'false'` are accepted. **EIP-7702** helpers also gain stricter validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b68a464aff452cc10a6b8ef18c1cc54dec43c5cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->