### PR TITLE
ci: use OIDC token-exchange for gh-pages deploys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,3 +124,4 @@ jobs:
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,4 +124,3 @@ jobs:
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,6 +6,9 @@ on:
       destination_dir:
         required: true
         type: string
+    secrets:
+      PUBLISH_DOCS_TOKEN:
+        required: true
 
 jobs:
   publish-docs-to-gh-pages:
@@ -28,6 +31,8 @@ jobs:
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
         uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # This `PUBLISH_DOCS_TOKEN` needs to be manually set per-repository.
+          # Look in the repository settings under "Environments", and set this token in the `github-pages` environment.
+          personal_token: ${{ secrets.PUBLISH_DOCS_TOKEN }}
           publish_dir: ./docs
           destination_dir: ${{ inputs.destination_dir }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -31,8 +31,6 @@ jobs:
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
         uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
         with:
-          # This `PUBLISH_DOCS_TOKEN` needs to be manually set per-repository.
-          # Look in the repository settings under "Environments", and set this token in the `github-pages` environment.
           personal_token: ${{ secrets.PUBLISH_DOCS_TOKEN }}
           publish_dir: ./docs
           destination_dir: ${{ inputs.destination_dir }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,9 +6,6 @@ on:
       destination_dir:
         required: true
         type: string
-    secrets:
-      PUBLISH_DOCS_TOKEN:
-        required: true
 
 jobs:
   publish-docs-to-gh-pages:
@@ -16,11 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     environment: github-pages
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     steps:
       - name: Ensure `destination_dir` is not empty
         if: ${{ inputs.destination_dir == '' }}
         run: exit 1
+      - name: Get access token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            contents: write
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
@@ -31,6 +36,6 @@ jobs:
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
         uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
         with:
-          personal_token: ${{ secrets.PUBLISH_DOCS_TOKEN }}
+          personal_token: ${{ steps.get-token.outputs.token }}
           publish_dir: ./docs
           destination_dir: ${{ inputs.destination_dir }}

--- a/.github/workflows/publish-main-docs.yml
+++ b/.github/workflows/publish-main-docs.yml
@@ -12,3 +12,5 @@ jobs:
     uses: ./.github/workflows/publish-docs.yml
     with:
       destination_dir: staging
+    secrets:
+      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}

--- a/.github/workflows/publish-main-docs.yml
+++ b/.github/workflows/publish-main-docs.yml
@@ -8,9 +8,8 @@ jobs:
   publish-to-gh-pages:
     name: Publish docs to `staging` directory of `gh-pages` branch
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-docs.yml
     with:
       destination_dir: staging
-    secrets:
-      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}

--- a/.github/workflows/publish-rc-docs.yml
+++ b/.github/workflows/publish-rc-docs.yml
@@ -25,10 +25,9 @@ jobs:
   publish-to-gh-pages:
     name: Publish docs to `rc-${{ needs.get-release-version.outputs.release-version }}` directory of `gh-pages` branch
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-docs.yml
     needs: get-release-version
     with:
       destination_dir: rc-${{ needs.get-release-version.outputs.release-version }}
-    secrets:
-      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}

--- a/.github/workflows/publish-rc-docs.yml
+++ b/.github/workflows/publish-rc-docs.yml
@@ -30,3 +30,5 @@ jobs:
     needs: get-release-version
     with:
       destination_dir: rc-${{ needs.get-release-version.outputs.release-version }}
+    secrets:
+      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,6 +7,8 @@ on:
         required: false
       SLACK_WEBHOOK_URL:
         required: true
+      PUBLISH_DOCS_TOKEN:
+        required: true
 
 permissions:
   contents: read
@@ -115,6 +117,8 @@ jobs:
     uses: ./.github/workflows/publish-docs.yml
     with:
       destination_dir: ${{ needs.get-release-version.outputs.RELEASE_VERSION }}
+    secrets:
+      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
 
   publish-release-to-latest-gh-pages:
     name: Publish docs to `latest` directory of `gh-pages` branch
@@ -124,6 +128,8 @@ jobs:
     uses: ./.github/workflows/publish-docs.yml
     with:
       destination_dir: latest
+    secrets:
+      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
 
   publish-release:
     name: Publish to GitHub

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,8 +7,6 @@ on:
         required: false
       SLACK_WEBHOOK_URL:
         required: true
-      PUBLISH_DOCS_TOKEN:
-        required: true
 
 permissions:
   contents: read
@@ -113,23 +111,21 @@ jobs:
     name: Publish docs to `${{ needs.get-release-version.outputs.RELEASE_VERSION }}` directory of `gh-pages` branch
     needs: get-release-version
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-docs.yml
     with:
       destination_dir: ${{ needs.get-release-version.outputs.RELEASE_VERSION }}
-    secrets:
-      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
 
   publish-release-to-latest-gh-pages:
     name: Publish docs to `latest` directory of `gh-pages` branch
     needs: publish-npm
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-docs.yml
     with:
       destination_dir: latest
-    secrets:
-      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
 
   publish-release:
     name: Publish to GitHub


### PR DESCRIPTION
## Summary

Docs deploys to `gh-pages` were failing (GH013 ruleset rejection) because #421 switched the deploy token to `GITHUB_TOKEN`, which isn't allowed to bypass the org's push-protection ruleset on `gh-pages`.

Fixes it by switching to OIDC token-exchange (same pattern as [`MetaMask/snaps`](https://github.com/MetaMask/snaps/blob/main/.github/workflows/publish-github-pages.yml)): each deploy job exchanges its OIDC identity for a short-lived `contents: write` token via `MetaMask/github-tools/.github/actions/get-token@v1`, instead of using a stored secret.

## Why this approach over reverting to the old `PUBLISH_DOCS_TOKEN` secret

That secret still exists and would also fix the immediate issue, but it's been unused/unrotated since #421 — exactly the kind of staleness that let this regression go unnoticed. 

## Validation

- `actionlint v1.7.12`: 0 errors on all changed files
- Matches `snaps`' working implementation exactly (permissions, `get-token` step, `personal_token` wiring)
- `vars.TOKEN_EXCHANGE_URL` confirmed already inherited by this repo at the org level

## Caveat

Can't verify from the API whether the token-exchange service's server-side trust policy already allows `eth-sig-util` to bypass the `gh-pages` ruleset (it evidently does for `snaps`). If not yet configured, the `Get access token` step will fail with a clear error rather than a silent bad push.
